### PR TITLE
Fix for improper wire connections to BC pipes

### DIFF
--- a/common/mrtjp/projectred/multipart/wiring/wires/TileRedAlloy.java
+++ b/common/mrtjp/projectred/multipart/wiring/wires/TileRedAlloy.java
@@ -324,7 +324,7 @@ public class TileRedAlloy extends TileWire implements IRedstoneEmitter, IRedston
 		Block b = Block.blocksList[worldObj.getBlockId(x, y, z)];
 		if (b == null)
 			return false;
-		if (b.canProvidePower()) {
+		if (b.canProvidePower() && b.canConnectRedstone(worldObj, x, y, z, canConnectRedstoneDirectionMap[direction])) {
 			return true;
 		}
 		if (direction >= 0 && direction < 6 && canConnectRedstoneDirectionMap[direction] != -2 && b.canConnectRedstone(worldObj, x, y, z, canConnectRedstoneDirectionMap[direction])) {


### PR DESCRIPTION
Added a check to make sure that neighboring blocks are actually currently redstone-connectable, as some mod blocks change this at runtime.  This specifically addresses red allow wires erronously connecting to BC pipes when there is not a Gate attached to the pipe.
