### PR TITLE
fix timer/counter gui to only update from correct gate

### DIFF
--- a/common/mrtjp/projectred/integration/IntegrationCPH.java
+++ b/common/mrtjp/projectred/integration/IntegrationCPH.java
@@ -46,9 +46,10 @@ public class IntegrationCPH implements IClientPacketHandler {
 			GuiScreen g = Minecraft.getMinecraft().currentScreen;
 			if (g instanceof GuiTimer) {
 				GuiTimer tg = (GuiTimer) g;
-				tg.coords = b;
-				tg.face = face;
-				tg.timerInterval = interval;
+				if (tg.coords.equals(b)) {
+					tg.face = face;
+					tg.timerInterval = interval;
+				}
 			}
 		}
 	}
@@ -73,12 +74,13 @@ public class IntegrationCPH implements IClientPacketHandler {
 			GuiScreen g = Minecraft.getMinecraft().currentScreen;
 			if (g instanceof GuiCounter) {
 				GuiCounter cg = (GuiCounter) g;
-				cg.coords = b;
-				cg.face = face;
-				cg.value = value;
-				cg.max = max;
-				cg.incr = incr;
-				cg.decr = decr;
+				if (cg.coords.equals(b)) {
+					cg.face = face;
+					cg.value = value;
+					cg.max = max;
+					cg.incr = incr;
+					cg.decr = decr;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
On a test world with multiple timers going at different speeds, opening a gui for one would show the time interval quickly flashing between the different speeds.
