### PR TITLE
Moved block and item creation from init to preinit; Fixed proxy system

### DIFF
--- a/common/mrtjp/projectred/core/ClientProxy.java
+++ b/common/mrtjp/projectred/core/ClientProxy.java
@@ -26,7 +26,7 @@ public class ClientProxy extends CommonProxy {
     public void postinit() {
         super.postinit();
         for (IProjectRedModule m : initializedModules) {
-            m.getCommonProxy().postinit();
+            m.getClientProxy().postinit();
         }
     }
 }

--- a/common/mrtjp/projectred/core/CoreClientProxy.java
+++ b/common/mrtjp/projectred/core/CoreClientProxy.java
@@ -9,7 +9,10 @@ import net.minecraft.item.ItemStack;
 import net.minecraftforge.common.MinecraftForge;
 import cpw.mods.fml.common.registry.LanguageRegistry;
 
-public class CoreClientProxy extends CoreProxy {
+public class CoreClientProxy implements IProxy {
+
+    @Override
+    public void preinit(){}
 
     @Override
     public void init() {
@@ -25,4 +28,7 @@ public class CoreClientProxy extends CoreProxy {
         
         MinecraftForge.EVENT_BUS.register(new Messenger());
     }
+
+    @Override
+    public void postinit() {}
 }

--- a/common/mrtjp/projectred/core/CoreProxy.java
+++ b/common/mrtjp/projectred/core/CoreProxy.java
@@ -14,14 +14,13 @@ public class CoreProxy implements IProxy {
 
     @Override
     public void preinit() {
+        itemComponent = new ItemPart(Configurator.item_componentsID.getInt());
+        itemDrawPlate = new ItemDrawPlate(Configurator.item_drawplateID.getInt());
+        itemBackpack = new ItemBackpack(Configurator.item_backpackID.getInt());
     }
 
     @Override
     public void init() {
-        itemComponent = new ItemPart(Configurator.item_componentsID.getInt());
-        itemDrawPlate = new ItemDrawPlate(Configurator.item_drawplateID.getInt());
-        itemBackpack = new ItemBackpack(Configurator.item_backpackID.getInt());
-
         EnumPart.initOreDictDefinitions();
         CoreRecipes.initCoreRecipes();
     }

--- a/common/mrtjp/projectred/expansion/ExpansionClientProxy.java
+++ b/common/mrtjp/projectred/expansion/ExpansionClientProxy.java
@@ -3,12 +3,16 @@ package mrtjp.projectred.expansion;
 import static mrtjp.projectred.ProjectRed.blockMachines;
 import static mrtjp.projectred.ProjectRed.itemVAWT;
 import mrtjp.projectred.core.Configurator;
+import mrtjp.projectred.core.IProxy;
 import mrtjp.projectred.expansion.BlockMachines.EnumMachine;
 import net.minecraft.item.ItemStack;
 import codechicken.lib.packet.PacketCustom;
 import cpw.mods.fml.common.registry.LanguageRegistry;
 
-public class ExpansionClientProxy extends ExpansionProxy {
+public class ExpansionClientProxy implements IProxy {
+
+    @Override
+    public void preinit(){}
 
     @Override
     public void init() {
@@ -19,4 +23,7 @@ public class ExpansionClientProxy extends ExpansionProxy {
         }
         LanguageRegistry.addName(new ItemStack(itemVAWT, 1, 0), "Vertical-Axis Wind Turbine");
     }
+
+    @Override
+    public void postinit() {}
 }

--- a/common/mrtjp/projectred/expansion/ExpansionProxy.java
+++ b/common/mrtjp/projectred/expansion/ExpansionProxy.java
@@ -11,11 +11,6 @@ public class ExpansionProxy implements IProxy {
 
     @Override
     public void preinit() {
-
-    }
-
-    @Override
-    public void init() {
         blockMachines = new BlockMachines(Configurator.block_machinesID.getInt());
         GameRegistry.registerBlock(blockMachines, ItemBlockMachines.class, "projectred.expansion.machines");
         for (EnumMachine m : EnumMachine.VALID_MACHINES) {
@@ -23,6 +18,10 @@ public class ExpansionProxy implements IProxy {
         }
 
         itemVAWT = new ItemVAWT(Configurator.item_vawtID.getInt());
+    }
+
+    @Override
+    public void init() {
         ExpansionRecipes.initRecipes();
     }
 

--- a/common/mrtjp/projectred/exploration/ExplorationClientProxy.java
+++ b/common/mrtjp/projectred/exploration/ExplorationClientProxy.java
@@ -3,12 +3,13 @@ package mrtjp.projectred.exploration;
 import static mrtjp.projectred.ProjectRed.*;
 import static mrtjp.projectred.ProjectRed.itemWoolGin;
 import net.minecraftforge.client.MinecraftForgeClient;
+import mrtjp.projectred.core.IProxy;
 import mrtjp.projectred.exploration.BlockOre.EnumOre;
 import mrtjp.projectred.exploration.BlockSpecialStone.EnumSpecialStone;
 import mrtjp.projectred.exploration.ItemGemSaw.GemSawItemRenderer;
 import cpw.mods.fml.common.registry.LanguageRegistry;
 
-public class ExplorationClientProxy extends ExplorationProxy {
+public class ExplorationClientProxy implements IProxy {
 
     @Override
     public void preinit(){}

--- a/common/mrtjp/projectred/exploration/ExplorationProxy.java
+++ b/common/mrtjp/projectred/exploration/ExplorationProxy.java
@@ -64,10 +64,6 @@ public class ExplorationProxy implements IProxy {
 
     @Override
     public void preinit() {
-    }
-
-    @Override
-    public void init() {
         GameRegistry.registerWorldGenerator(GenerationManager.instance);
 
         itemWoolGin = new ItemWoolGin(Configurator.item_woolginID.getInt());
@@ -80,16 +76,6 @@ public class ExplorationProxy implements IProxy {
 
         blockStones = new BlockSpecialStone(Configurator.block_stonesID.getInt());
         GameRegistry.registerBlock(blockStones, ItemBlockSpecialStone.class, "projectred.exploration.stone");
-
-        if (Configurator.gen_SpreadingMoss.getBoolean(true)) {
-            int mc = Block.cobblestoneMossy.blockID;
-            Block.blocksList[mc] = null;
-            new BlockPhotosyntheticCobblestone(mc);
-
-            int sb = Block.stoneBrick.blockID;
-            Block.blocksList[sb] = null;
-            new BlockPhotosyntheticStoneBrick(sb);
-        }
 
         toolMaterialRuby = EnumHelper.addToolMaterial("RUBY", 2, 500, 8.0F, 4, 12);
         toolMaterialSapphire = EnumHelper.addToolMaterial("SAPPHIRE", 2, 500, 8.0F, 3, 16);
@@ -147,6 +133,19 @@ public class ExplorationProxy implements IProxy {
         itemSapphireSickle = new ItemGemSickle(Configurator.item_sapphireSickle.getInt(), EnumSpecialTool.SAPPHIRESICKLE);
         itemPeridotSickle = new ItemGemSickle(Configurator.item_peridotSickle.getInt(), EnumSpecialTool.PERIDOTSICKLE);
         itemDiamondSickle = new ItemGemSickle(Configurator.item_diamondSickle.getInt(), EnumSpecialTool.DIAMONDSICKLE);
+    }
+
+    @Override
+    public void init() {
+        if (Configurator.gen_SpreadingMoss.getBoolean(true)) {
+            int mc = Block.cobblestoneMossy.blockID;
+            Block.blocksList[mc] = null;
+            new BlockPhotosyntheticCobblestone(mc);
+
+            int sb = Block.stoneBrick.blockID;
+            Block.blocksList[sb] = null;
+            new BlockPhotosyntheticStoneBrick(sb);
+        }
 
         ExplorationRecipes.initRecipes();
     }

--- a/common/mrtjp/projectred/illumination/IlluminationClientProxy.java
+++ b/common/mrtjp/projectred/illumination/IlluminationClientProxy.java
@@ -1,11 +1,15 @@
 package mrtjp.projectred.illumination;
 
 import mrtjp.projectred.ProjectRed;
+import mrtjp.projectred.core.IProxy;
 import net.minecraftforge.client.MinecraftForgeClient;
 import net.minecraftforge.common.MinecraftForge;
 import cpw.mods.fml.common.registry.LanguageRegistry;
 
-public class IlluminationClientProxy extends IlluminationProxy {
+public class IlluminationClientProxy implements IProxy {
+
+    @Override
+    public void preinit(){}
 
     @Override
     public void init() {
@@ -24,4 +28,7 @@ public class IlluminationClientProxy extends IlluminationProxy {
         
         MinecraftForge.EVENT_BUS.register(LastEventBasedHaloRenderer.instance);
     }
+
+    @Override
+    public void postinit() {}
 }

--- a/common/mrtjp/projectred/illumination/IlluminationProxy.java
+++ b/common/mrtjp/projectred/illumination/IlluminationProxy.java
@@ -14,18 +14,16 @@ public class IlluminationProxy implements IProxy, IPartFactory {
 
     @Override
     public void preinit() {
-
-    }
-
-    @Override
-    public void init() {
-        MultiPartRegistry.registerParts(this, new String[] { "Lantern", "inv.Lantern", "Lamp", "inv.Lamp" });
-
         itemPartLantern = new ItemPartLantern(Configurator.part_lantern.getInt(), false);
         itemPartInvLantern = new ItemPartLantern(Configurator.part_invlantern.getInt(), true);
 
         itemPartLamp = new ItemPartLamp(Configurator.part_lamp.getInt(), false);
         itemPartInvLamp = new ItemPartLamp(Configurator.part_invlamp.getInt(), true);
+    }
+
+    @Override
+    public void init() {
+        MultiPartRegistry.registerParts(this, new String[] { "Lantern", "inv.Lantern", "Lamp", "inv.Lamp" });
 
         IlluminationRecipes.initIlluminationRecipes();
         EnumLamp.initOreDictDefinitions();

--- a/common/mrtjp/projectred/integration/IntegrationClientProxy.java
+++ b/common/mrtjp/projectred/integration/IntegrationClientProxy.java
@@ -3,11 +3,16 @@ package mrtjp.projectred.integration;
 import static mrtjp.projectred.ProjectRed.itemScrewdriver;
 import mrtjp.projectred.ProjectRed;
 import mrtjp.projectred.core.Configurator;
+import mrtjp.projectred.core.IProxy;
 import net.minecraftforge.client.MinecraftForgeClient;
 import codechicken.lib.packet.PacketCustom;
 import cpw.mods.fml.common.registry.LanguageRegistry;
 
-public class IntegrationClientProxy extends IntegrationProxy {
+public class IntegrationClientProxy implements IProxy {
+
+    @Override
+    public void preinit(){}
+
     @Override
     public void init() {
         MinecraftForgeClient.registerItemRenderer(ProjectRed.itemPartGate.itemID, GateStaticRenderer.instance);
@@ -20,4 +25,6 @@ public class IntegrationClientProxy extends IntegrationProxy {
         PacketCustom.assignHandler(Configurator.integrationPacketChannel, 0, 32, new IntegrationCPH());
     }
 
+    @Override
+    public void postinit() {}
 }

--- a/common/mrtjp/projectred/integration/IntegrationProxy.java
+++ b/common/mrtjp/projectred/integration/IntegrationProxy.java
@@ -14,6 +14,8 @@ public class IntegrationProxy implements IProxy, IPartFactory {
 
     @Override
     public void preinit() {
+        itemPartGate = new ItemPartGate(Configurator.part_gate.getInt());
+        itemScrewdriver = new ItemScrewdriver(Configurator.item_screwdriverID.getInt());
     }
     
     @Override
@@ -24,9 +26,6 @@ public class IntegrationProxy implements IProxy, IPartFactory {
         }
         MultiPartRegistry.registerParts(this, gates);
 
-        itemPartGate = new ItemPartGate(Configurator.part_gate.getInt());
-        itemScrewdriver = new ItemScrewdriver(Configurator.item_screwdriverID.getInt());
-        
         MultipartGenerator.registerPassThroughInterface("dan200.computer.api.IPeripheral");
         IntegrationRecipes.initIntegrationRecipes();
         EnumGate.initOreDictDefinitions();

--- a/common/mrtjp/projectred/transmission/TransmissionClientProxy.java
+++ b/common/mrtjp/projectred/transmission/TransmissionClientProxy.java
@@ -2,10 +2,14 @@ package mrtjp.projectred.transmission;
 
 import static mrtjp.projectred.ProjectRed.itemPartJacketedWire;
 import static mrtjp.projectred.ProjectRed.itemPartWire;
+import mrtjp.projectred.core.IProxy;
 import net.minecraftforge.client.MinecraftForgeClient;
 import cpw.mods.fml.common.registry.LanguageRegistry;
 
-public class TransmissionClientProxy extends TransmissionProxy {
+public class TransmissionClientProxy implements IProxy {
+
+    @Override
+    public void preinit() {}
 
     @Override
     public void init() {
@@ -16,4 +20,7 @@ public class TransmissionClientProxy extends TransmissionProxy {
         MinecraftForgeClient.registerItemRenderer(itemPartWire.itemID, WireItemRenderer.instance);
         MinecraftForgeClient.registerItemRenderer(itemPartJacketedWire.itemID, JacketedWireItemRenderer.instance);
     }
+
+    @Override
+    public void postinit() {}
 }

--- a/common/mrtjp/projectred/transmission/TransmissionProxy.java
+++ b/common/mrtjp/projectred/transmission/TransmissionProxy.java
@@ -12,7 +12,8 @@ public class TransmissionProxy implements IProxy, IPartFactory {
 
     @Override
     public void preinit() {
-
+        itemPartWire = new ItemPartWire(Configurator.part_wire.getInt());
+        itemPartJacketedWire = new ItemPartJacketedWire(Configurator.part_jwire.getInt());
     }
 
     @Override
@@ -26,9 +27,6 @@ public class TransmissionProxy implements IProxy, IPartFactory {
         }
         MultiPartRegistry.registerParts(this, wires);
         MultiPartRegistry.registerParts(this, jwires);
-
-        itemPartWire = new ItemPartWire(Configurator.part_wire.getInt());
-        itemPartJacketedWire = new ItemPartJacketedWire(Configurator.part_jwire.getInt());
 
         TransmissionRecipes.initTransmissionRecipes();
         EnumWire.initOreDictDefinitions();


### PR DESCRIPTION
I tried to build and use the version from `master` branch and encountered a crash, which was caused by attempting to register a recipe which uses Saw before the Saw is actually constructed.

According to FML's Javadoc, PreInitialization is a valid place to construct and register items and blocks.

Then I encountered another issue.
Let's look at CoreClientProxy class. It inherits CoreProxy.
Let's look at ClientProxy class. It inherits CommonProxy and calls methods from superclass.

As a result, there's a problem: proxy methods may be called twice. I hope you see the problem now because I have trouble trying to explain what's wrong.
