### PR TITLE
Use forge method for providing XP Drops, fixes #318

### DIFF
--- a/common/mrtjp/projectred/exploration/BlockOre.java
+++ b/common/mrtjp/projectred/exploration/BlockOre.java
@@ -48,9 +48,15 @@ public class BlockOre extends Block
             count = max;
         if (count < min)
             count = min;
-        dropXpOnBlockBreak(world, x, y, z, MathHelper.getRandomIntegerInRange(world.rand, type.minXP, type.maxXP));
         ret.add(type.getDropStack(count));
         return ret;
+    }
+
+    @Override
+    public int getExpDrop(World world, int data, int enchantmentLevel)
+    {
+        EnumOre type = EnumOre.VALID_ORES[data];
+        return MathHelper.getRandomIntegerInRange(world.rand, type.minXP, type.maxXP);
     }
 
     @Override
@@ -89,7 +95,7 @@ public class BlockOre extends Block
 
         public final String name;
         public final String unlocal;
-        public final int harvesLevel;
+        public final int harvestLevel;
         public final ItemStack drop;
         public final int minDrop;
         public final int maxDrop;
@@ -110,7 +116,7 @@ public class BlockOre extends Block
         {
             this.name = name;
             this.unlocal = unlocal;
-            this.harvesLevel = harvestLevel;
+            this.harvestLevel = harvestLevel;
             this.drop = drop;
             this.minDrop = min;
             this.maxDrop = max;

--- a/common/mrtjp/projectred/exploration/proxies.scala
+++ b/common/mrtjp/projectred/exploration/proxies.scala
@@ -32,7 +32,7 @@ class ExplorationProxy_server extends IProxy with IGuiHandler
 
         blockOres = new BlockOre(Configurator.block_oresID.getInt)
         GameRegistry.registerBlock(blockOres, classOf[ItemBlockOre], "projectred.exploration.ore")
-        for (o <- EnumOre.VALID_ORES) MinecraftForge.setBlockHarvestLevel(blockOres, "pickaxe", o.harvesLevel)
+        for (o <- EnumOre.VALID_ORES) MinecraftForge.setBlockHarvestLevel(blockOres, "pickaxe", o.harvestLevel)
 
         blockStones = new BlockSpecialStone(Configurator.block_stonesID.getInt)
         GameRegistry.registerBlock(blockStones, classOf[ItemBlockSpecialStone], "projectred.exploration.stone")


### PR DESCRIPTION
By using getExpDrop, the XP drop is passed through forge event handling system allowing fake players for example to not drop XP
Also fixes spelling of harvestLevel
