### PR TITLE
Add target exclude for sbt-eclipse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@ Thumbs.db
 /logs/
 options.txt
 /saves/
+#sbt-eclipse junk
+/target/
 #Modeling stuff
 *.blend1
 *.blend2


### PR DESCRIPTION
When I use sbt-eclipse I get this target folder, so I'm excluding it for anyone else who needs it excluded when building.
