### PR TITLE
Fix shader conflict

### DIFF
--- a/src/mrtjp/projectred/illumination/renders.scala
+++ b/src/mrtjp/projectred/illumination/renders.scala
@@ -45,6 +45,7 @@ object RenderHalo
     @SubscribeEvent
     def onRenderWorldLast(event:RenderWorldLastEvent)
     {
+        if (renderList.size == 0) return
         val w = Minecraft.getMinecraft.theWorld
         val entity = Minecraft.getMinecraft.renderViewEntity
         renderEntityPos.set(entity.posX, entity.posY+entity.getEyeHeight, entity.posZ)


### PR DESCRIPTION
Turns out that having no lights results in the brightness being turned down for some reason. This fixes that.
