### PR TITLE
Fix Creative Inventory Search data card NPE crash

### DIFF
--- a/src/mrtjp/projectred/core/items.scala
+++ b/src/mrtjp/projectred/core/items.scala
@@ -234,7 +234,7 @@ class ItemDataCard extends ItemCore("projectred.core.datacard")
     override def addInformation(stack:ItemStack, player:EntityPlayer, list:JList[_], par4:Boolean)
     {
         val l2 = list.asInstanceOf[JList[String]]
-        if (Keyboard.isKeyDown(Keyboard.KEY_LSHIFT)||Keyboard.isKeyDown(Keyboard.KEY_RSHIFT) && stack.hasTagCompound)
+        if ((Keyboard.isKeyDown(Keyboard.KEY_LSHIFT)||Keyboard.isKeyDown(Keyboard.KEY_RSHIFT)) && stack.hasTagCompound)
         {
             val tag = stack.getTagCompound
             import JavaConversions._


### PR DESCRIPTION
This fixes issue #484 and  #478
Detailed information can be seen on this comment https://github.com/MrTJP/ProjectRed/issues/484#issuecomment-47157314

Travis-CI failed to download a file. Worked for my fork https://travis-ci.org/simon816/ProjectRed/builds/28446861
