### PR TITLE
Bugfix help

### DIFF
--- a/src/mrtjp/projectred/core/lib/LabelBreaks.scala
+++ b/src/mrtjp/projectred/core/lib/LabelBreaks.scala
@@ -35,6 +35,11 @@ class LabelThrowable extends ControlThrowable
         ident = tag
         this
     }
+
+    override def toString() =
+    {
+        super.toString() + ": " + ident
+    }
 }
 
 object LabelBreaks extends LabelBreaks


### PR DESCRIPTION
Make LabelThrowable show the label that failed if it propogates, so it can be tracked.
