### PR TITLE
Sacrifice performance for thread safety

### DIFF
--- a/src/mrtjp/projectred/core/lib/LabelBreaks.scala
+++ b/src/mrtjp/projectred/core/lib/LabelBreaks.scala
@@ -4,8 +4,6 @@ import scala.util.control.ControlThrowable
 
 class LabelBreaks
 {
-    val throwable = new LabelThrowable()
-
     def label(tag:String)(op: => Any):Unit =
     {
         try
@@ -19,7 +17,7 @@ class LabelBreaks
         }
     }
 
-    def break(tag:String):Unit = throw throwable(tag)
+    def break(tag:String):Unit = throw new LabelThrowable()(tag)
 
     //Shorthand single break
     def label(op: => Any):Unit = label("$1")(op)


### PR DESCRIPTION
Issue #521 is, as far as I can tell, a race condition involving the fact that only one `LabelThrowable` is ever created. This throwable gets its value reassigned with every break statement, and two threads doing it at the same time with different tags breaks it severely, causing the errors we've been getting.

This PR will resolve that by creating a new throwable every time `break` is called. This may cause performance problems, and using one instance per thread may be preferable. I can implement that if wanted.
