### PR TITLE
Create the Creative Routing CPU

### DIFF
--- a/resources/assets/projectred/lang/en_US.lang
+++ b/resources/assets/projectred/lang/en_US.lang
@@ -82,6 +82,7 @@ item.projectred.transportation.routingchip|6.name=Item Stock Keeper chip
 item.projectred.transportation.routingchip|7.name=Item Crafting chip
 
 item.projectred.transportation.cpu|0.name=Routing Network CPU
+item.projectred.transportation.creativecpu|0.name=Creative Routing Network CPU
 
 item.projectred.transportation.routerutil.name=Router Utility
 

--- a/src/mrtjp/projectred/ProjectRedTransportation.scala
+++ b/src/mrtjp/projectred/ProjectRedTransportation.scala
@@ -15,6 +15,7 @@ object ProjectRedTransportation
     var itemRoutingChip:ItemRoutingChip = null
     var itemRouterUtility:ItemRouterUtility = null
     var itemRouterCPU:ItemCPU = null
+    var itemRouterCreativeCPU:ItemCreativeCPU = null
 
     /** Multipart items **/
     var itemPartPipe:ItemPartPipe = null

--- a/src/mrtjp/projectred/expansion/TileRouterController.scala
+++ b/src/mrtjp/projectred/expansion/TileRouterController.scala
@@ -4,7 +4,7 @@ import codechicken.lib.data.{MCDataInput, MCDataOutput}
 import mrtjp.projectred.ProjectRedExpansion
 import mrtjp.projectred.core.GuiManager
 import mrtjp.projectred.core.libmc.inventory.{SimpleInventory, Slot2, WidgetContainer}
-import mrtjp.projectred.transportation.{ItemCPU, TControllerLayer}
+import mrtjp.projectred.transportation.{ItemCPU, ItemCreativeCPU, TControllerLayer}
 import net.minecraft.entity.player.EntityPlayer
 import net.minecraft.item.ItemStack
 import net.minecraft.nbt.NBTTagCompound
@@ -14,7 +14,7 @@ class TileRouterController extends TileMachine with TileGuiMachine with TControl
     val cpuSlot = new SimpleInventory(1, "inv", 1)
     {
         override def isItemValidForSlot(i:Int, stack:ItemStack) =
-            stack != null && stack.getItem.isInstanceOf[ItemCPU]
+            stack != null && (stack.getItem.isInstanceOf[ItemCPU] || stack.getItem.isInstanceOf[ItemCreativeCPU])
 
         override def markDirty()
         {
@@ -55,7 +55,7 @@ class TileRouterController extends TileMachine with TileGuiMachine with TControl
     {
         super.update()
         val stack = cpuSlot.getStackInSlot(0)
-        if (stack != null)
+        if (stack != null && !stack.getItem.isInstanceOf[ItemCreativeCPU])
         {
             assureNBT(stack)
             if (stack.getTagCompound.getDouble("cycles") <= 0)
@@ -78,8 +78,12 @@ class TileRouterController extends TileMachine with TileGuiMachine with TControl
         val stack = cpuSlot.getStackInSlot(0)
         if (stack != null)
         {
-            assureNBT(stack)
-            stack.getTagCompound.getDouble("cycles")
+            if (stack.getItem.isInstanceOf[ItemCreativeCPU]) {
+                Short.MaxValue
+            } else {
+                assureNBT(stack)
+                stack.getTagCompound.getDouble("cycles")
+            }
         }
         else 0
     }
@@ -89,10 +93,14 @@ class TileRouterController extends TileMachine with TileGuiMachine with TControl
         val stack = cpuSlot.getStackInSlot(0)
         if (stack != null)
         {
-            assureNBT(stack)
-            val newPow = stack.getTagCompound.getDouble("cycles")-P
-            stack.getTagCompound.setDouble("cycles", newPow)
-            newPow >= 0
+            if (stack.getItem.isInstanceOf[ItemCreativeCPU]) {
+                true
+            } else {
+                assureNBT(stack)
+                val newPow = stack.getTagCompound.getDouble("cycles")-P
+                stack.getTagCompound.setDouble("cycles", newPow)
+                newPow >= 0
+            }
         }
         else false
     }

--- a/src/mrtjp/projectred/transportation/items.scala
+++ b/src/mrtjp/projectred/transportation/items.scala
@@ -259,6 +259,21 @@ class ItemCPU extends ItemCore("projectred.transportation.cpu")
     }
 }
 
+class ItemCreativeCPU extends ItemCore("projectred.transportation.creativecpu")
+{
+    setCreativeTab(ProjectRedTransportation.tabTransportation)
+    setHasSubtypes(false)
+    setMaxStackSize(1)
+    setTextureName("projectred:cpu")
+
+    override def addInformation(stack:ItemStack, player:EntityPlayer, list:JList[_], par4:Boolean)
+    {
+        val list2 = list.asInstanceOf[JList[String]]
+        if (Keyboard.isKeyDown(Keyboard.KEY_LSHIFT) || Keyboard.isKeyDown(Keyboard.KEY_RSHIFT))
+            list2.add("Infinite cycles remaining")
+    }
+}
+
 class ChipUpgradeContainer(player:EntityPlayer) extends WidgetContainer
 {
     val upgradeInv = new SimpleInventory(7, "upBus", 1)

--- a/src/mrtjp/projectred/transportation/proxies.scala
+++ b/src/mrtjp/projectred/transportation/proxies.scala
@@ -28,6 +28,7 @@ class TransportationProxy_server extends IProxy with IPartFactory
         itemRoutingChip = new ItemRoutingChip
         itemRouterUtility = new ItemRouterUtility
         itemRouterCPU = new ItemCPU
+        itemRouterCreativeCPU = new ItemCreativeCPU
 
         for (i <- 0 until Configurator.routerUpdateThreadCount) new TableUpdateThread(i)
     }


### PR DESCRIPTION
Creative Routing CPU for the Routing Controller.

Problems:
- ItemCreativeCPU doesn't extend ItemCPU (constructor limitation)
- [ ] Other language files need to be updated with the new name.
