### PR TITLE
Register Red Alloy Ingot as ingotRedAlloy in Oredict

### DIFF
--- a/src/mrtjp/projectred/core/items.scala
+++ b/src/mrtjp/projectred/core/items.scala
@@ -152,6 +152,8 @@ object PartDefs extends ItemDefinition
     def initOreDict()
     {
         for (i <- ILLUMARS) OreDictionary.registerOre(oreDictDefinitionIllumar, i.makeStack)
+
+        OreDictionary.registerOre("ingotRedAlloy", REDINGOT.makeStack);
     }
 
     class PartVal(iconName:String) extends ItemDef


### PR DESCRIPTION
This would allow cross-mod-compatibility.

For Example GregTech also implements an Red Alloy Ingot
