### PR TITLE
Re-enable compatibility with Tinker's Construct and Thermal Expansion

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,13 +18,6 @@ buildscript {
     }
 }
 
-repositories {
-    maven {
-        name "chickenbones"
-        url "http://chickenbones.net/maven/"
-    }
-}
-
 // Apply the forge plugin - this adds all the magic for automatically obfuscating, deobfuscating etc
 apply plugin: 'scala'
 apply plugin: 'forge'
@@ -44,12 +37,42 @@ configFile.withReader {
     project.ext.config = new ConfigSlurper().parse prop
 }
 
+// Must be after config to access config.*
+repositories {
+    maven {
+        name "chickenbones"
+        url "http://chickenbones.net/maven/"
+    }
+
+    maven {
+        name "dvs1"
+        url "http://dvs1.progwml6.com/files/maven/"
+    }
+    ivy {
+        name 'ThermalExpansion'
+        artifactPattern "http://addons.cursecdn.com/files/${config.texpan.cf}/[module]-[revision].[ext]"
+    }
+    ivy {
+        name 'CoFHCore'
+        artifactPattern "http://addons.cursecdn.com/files/${config.cofh.cf}/[module]-[revision].[ext]"
+    }
+}
+
+configurations {
+	buildOnly
+}
+
 dependencies {
     compile "codechicken:CodeChickenLib:${config.mc.version}-${config.ccl.version}:dev"
     compile "codechicken:ForgeMultipart:${config.mc.version}-${config.fmp.version}:dev"
     compile "codechicken:CodeChickenCore:${config.mc.version}-${config.ccc.version}:dev"
     compile "codechicken:NotEnoughItems:${config.mc.version}-${config.nei.version}:dev"
+    buildOnly "tconstruct:TConstruct:${config.mc.version}-${config.tc.version}:deobf"
+    buildOnly name: 'ThermalExpansion', version: config.texpan.version, ext: 'jar'
+    buildOnly name: 'CoFHCore', version: config.cofh.version, ext: 'jar'
 }
+
+sourceSets.main.compileClasspath += [ configurations.buildOnly ]
 
 def build_number = (System.getenv("BUILD_NUMBER") ?: "1")
 version =  "${project.config.mod.version}." + build_number

--- a/build.properties
+++ b/build.properties
@@ -8,3 +8,11 @@ ccc.version=1.0.3.26
 fmp.version=1.1.0.307
 
 nei.version=1.0.3.56
+
+tc.version=1.7.0.build734
+
+texpan.version=[1.7.10]4.0.0B5-13
+texpan.cf=2212/447
+
+cofh.version=[1.7.10]3.0.0B6-dev-32
+cofh.cf=2212/895

--- a/src/mrtjp/projectred/compatibility/Services.scala
+++ b/src/mrtjp/projectred/compatibility/Services.scala
@@ -3,6 +3,8 @@ package mrtjp.projectred.compatibility
 import cpw.mods.fml.common.Loader
 import mrtjp.projectred.compatibility.computercraft.PluginCC_BundledCable
 import mrtjp.projectred.compatibility.treecapitator.PluginTreecapitator
+import mrtjp.projectred.compatibility.tconstruct.PluginTConstruct
+import mrtjp.projectred.compatibility.thermalexpansion.PluginThermalExpansion
 import mrtjp.projectred.core.PRLogger
 
 object Services
@@ -10,7 +12,9 @@ object Services
     //Hardcoded list of all possible plugins
     val rootPlugins = Seq[IPRPlugin](
         PluginTreecapitator,
-        PluginCC_BundledCable
+        PluginCC_BundledCable,
+        PluginTConstruct,
+        PluginThermalExpansion
     )
 
     //List of all loaded plugins

--- a/src/mrtjp/projectred/compatibility/tconstruct/LiquidFiniteSubstance.java
+++ b/src/mrtjp/projectred/compatibility/tconstruct/LiquidFiniteSubstance.java
@@ -1,6 +1,5 @@
 package mrtjp.projectred.compatibility.tconstruct;
 
-/*
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.Entity;
@@ -59,4 +58,3 @@ public class LiquidFiniteSubstance extends BlockFluidFinite
         }
     }
 }
-*/

--- a/src/mrtjp/projectred/compatibility/tconstruct/PluginTConstruct.scala
+++ b/src/mrtjp/projectred/compatibility/tconstruct/PluginTConstruct.scala
@@ -1,20 +1,19 @@
 package mrtjp.projectred.compatibility.tconstruct
 
-/*
 import cpw.mods.fml.common.registry.GameRegistry
 import net.minecraft.block.Block
 import net.minecraft.block.material.{MapColor, MaterialLiquid, Material}
 import net.minecraft.item.ItemStack
 import net.minecraft.init.{Blocks, Items}
 import net.minecraftforge.fluids.{FluidStack, FluidRegistry, Fluid}
-import tconstruct.common.TRepo._
 import tconstruct.library.TConstructRegistry
 import tconstruct.library.crafting.Smeltery
+import tconstruct.smeltery.TinkerSmeltery._
 import mrtjp.projectred.compatibility.IPRPlugin
 import tconstruct.TConstruct
 import mrtjp.projectred.core.PartDefs
 
-class PluginTConstruct extends IPRPlugin
+object PluginTConstruct extends IPRPlugin
 {
     var liquidMetal:Material = null
     var moltenRedstoneFluid:Fluid = null
@@ -22,7 +21,7 @@ class PluginTConstruct extends IPRPlugin
     var moltenConductiveRedmetalFluid:Fluid = null
     var moltenConductiveRedmetal:LiquidFiniteSubstance = null
 
-    override def getModID = "TConstruct"
+    override def getModIDs = Array("TConstruct")
 
     def addSmeltingRecipe(input:ItemStack, block:Block, metadata:Int, temperature:Int, liquid:FluidStack)
     {
@@ -80,5 +79,6 @@ class PluginTConstruct extends IPRPlugin
     }
 
     override def postInit() {}
+
+    override def desc() = "Red Alloy Ingot recipe for Tinker's Construct"
 }
-*/

--- a/src/mrtjp/projectred/compatibility/thermalexpansion/LinkStateTesseract.java
+++ b/src/mrtjp/projectred/compatibility/thermalexpansion/LinkStateTesseract.java
@@ -1,14 +1,14 @@
 package mrtjp.projectred.compatibility.thermalexpansion;
 
-/*
 import codechicken.lib.vec.BlockCoord;
 import codechicken.multipart.TMultiPart;
-import cofh.api.transport.IEnderAttuned;
+import cofh.api.transport.IEnderItemHandler;
+import cofh.api.transport.RegistryEnderAttuned;
 import mrtjp.projectred.api.ISpecialLinkState;
 import mrtjp.projectred.core.libmc.PRLib;
 import mrtjp.projectred.transportation.RoutedJunctionPipePart;
 import net.minecraft.tileentity.TileEntity;
-import thermalexpansion.block.tesseract.TileTesseract;
+import thermalexpansion.block.ender.TileTesseract;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -40,10 +40,13 @@ public class LinkStateTesseract implements ISpecialLinkState
     private List<TileTesseract> getConnectedTesseracts(TileTesseract tess)
     {
         List<TileTesseract> links = new LinkedList<TileTesseract>();
+        List<IEnderItemHandler> conns = RegistryEnderAttuned.getLinkedItemOutputs(tess);
 
-        List<IEnderAttuned> conns = tess.getValidItemOutputs();
-        for (IEnderAttuned obj : conns)
-            if (obj instanceof TileTesseract)
+        if (conns == null)
+            return links;
+
+        for (IEnderItemHandler obj : conns)
+            if (obj.canReceiveItems() && obj instanceof TileTesseract)
                 links.add((TileTesseract) obj);
 
         return links;
@@ -56,7 +59,7 @@ public class LinkStateTesseract implements ISpecialLinkState
 
         for (int i = 0; i < 6; i++)
         {
-            TMultiPart part = PRLib.getMultiPart(tess.worldObj, bc.copy().offset(i), 6);
+            TMultiPart part = PRLib.getMultiPart(tess.getWorldObj(), bc.copy().offset(i), 6);
             if (part instanceof RoutedJunctionPipePart)
             {
                 RoutedJunctionPipePart pipe = (RoutedJunctionPipePart) part;
@@ -75,7 +78,7 @@ public class LinkStateTesseract implements ISpecialLinkState
 
         for (int i = 0; i < 6; i++)
         {
-            TMultiPart part = PRLib.getMultiPart(tess.worldObj, bc.copy().offset(i), 6);
+            TMultiPart part = PRLib.getMultiPart(tess.getWorldObj(), bc.copy().offset(i), 6);
             if (part instanceof RoutedJunctionPipePart)
             {
                 RoutedJunctionPipePart pipe = (RoutedJunctionPipePart) part;
@@ -93,4 +96,3 @@ public class LinkStateTesseract implements ISpecialLinkState
         return tile instanceof TileTesseract;
     }
 }
-*/

--- a/src/mrtjp/projectred/compatibility/thermalexpansion/PluginThermalExpansion.scala
+++ b/src/mrtjp/projectred/compatibility/thermalexpansion/PluginThermalExpansion.scala
@@ -1,14 +1,15 @@
 package mrtjp.projectred.compatibility.thermalexpansion
 
-/*
 import mrtjp.projectred.compatibility.IPRPlugin
 import mrtjp.projectred.core.PartDefs
-import net.minecraft.item.{Item, ItemStack}
+import net.minecraft.init.Items
+import net.minecraft.item.ItemStack
 import thermalexpansion.util.crafting.SmelterManager
 
-class PluginTermalExpansion extends IPRPlugin
+object PluginThermalExpansion extends IPRPlugin
 {
-    override def getModID = "ThermalExpansion"
+
+    override def getModIDs = Array("ThermalExpansion")
 
     override def preInit() {}
 
@@ -18,10 +19,11 @@ class PluginTermalExpansion extends IPRPlugin
 //        if (ProjectRedAPI.transportationAPI != null)
 //            ProjectRedAPI.transportationAPI.registerSpecialLinkState(new LinkStateTesseract());
 
-        SmelterManager.addAlloyRecipe(4000, new ItemStack(Item.ingotIron),
-            new ItemStack(Item.redstone, 4), PartDefs.REDINGOT.makeStack)
+        SmelterManager.addAlloyRecipe(4000, new ItemStack(Items.iron_ingot),
+            new ItemStack(Items.redstone, 4), PartDefs.REDINGOT.makeStack)
     }
 
     override def postInit() {}
+
+    override def desc() = "Thermal Expansion smelter recipe"
 }
-*/


### PR DESCRIPTION
Tested and works for both mods.

I could not get the mods to load in a development environment so a new configuration `buildOnly` in the build.gradle had to be made. This means there will be missing classes in the build path of an IDE but will work when running `gradlew build`

I do not know much about Thermal Expansion, but is this comment still applicable in the later versions? :

``` java
        //     cant be used if tesseracts dont auto-eject into pipes.
//        if (ProjectRedAPI.transportationAPI != null)
//            ProjectRedAPI.transportationAPI.registerSpecialLinkState(new LinkStateTesseract());

```
