### PR TITLE
Use ore dictionary in recipes

### DIFF
--- a/src/mrtjp/projectred/core/items.scala
+++ b/src/mrtjp/projectred/core/items.scala
@@ -148,12 +148,13 @@ object PartDefs extends ItemDefinition
     val ILLUMARS = WHITEILLUMAR to BLACKILLUMAR
 
     val oreDictDefinitionIllumar = "projredIllumar"
+    val oreDictDefinitionRedIngot = "ingotRedAlloy"
 
     def initOreDict()
     {
         for (i <- ILLUMARS) OreDictionary.registerOre(oreDictDefinitionIllumar, i.makeStack)
 
-        OreDictionary.registerOre("ingotRedAlloy", REDINGOT.makeStack);
+        OreDictionary.registerOre(oreDictDefinitionRedIngot, REDINGOT.makeStack);
     }
 
     class PartVal(iconName:String) extends ItemDef

--- a/src/mrtjp/projectred/transmission/TransmissionRecipes.scala
+++ b/src/mrtjp/projectred/transmission/TransmissionRecipes.scala
@@ -19,15 +19,15 @@ object TransmissionRecipes
 
     private def initWireRecipes()
     {
-        GameRegistry.addRecipe(WireDef.RED_ALLOY.makeStack(12),
+        GameRegistry.addRecipe(new ShapedOreRecipe(WireDef.RED_ALLOY.makeStack(12),
             " r ", " r ", " r ",
-            'r':Character, PartDefs.REDINGOT.makeStack)
+            'r':Character, PartDefs.oreDictDefinitionRedIngot))
 
         for (w <- WireDef.INSULATED_WIRES)
-            GameRegistry.addRecipe(w.makeStack(12),
+            GameRegistry.addRecipe(new ShapedOreRecipe(w.makeStack(12),
                 "WrW", "WrW", "WrW",
                 'W':Character, new ItemStack(Blocks.wool, 1, PRColors.get(w.meta-WireDef.INSULATED_0.meta).woolId),
-                'r':Character, PartDefs.REDINGOT.makeStack)
+                'r':Character, PartDefs.oreDictDefinitionRedIngot))
 
         for (w <- WireDef.INSULATED_WIRES)
             GameRegistry.addRecipe(new ShapelessOreRecipe(


### PR DESCRIPTION
Update the wire recipes to use the ore dictionary values, fixes #589.
