### PR TITLE
Add MrTJPCoreMod as a required dependency

### DIFF
--- a/resources/base_mod.info
+++ b/resources/base_mod.info
@@ -13,11 +13,13 @@
   "requiredMods": [
       "Forge",
       "ForgeMultipart",
-      "CodeChickenCore"
+      "CodeChickenCore",
+      "MrTJPCoreMod"
   ],
   "dependencies": [
       "ForgeMultipart",
-      "CodeChickenCore"
+      "CodeChickenCore",
+      "MrTJPCoreMod"
   ],
   "dependants" : [
       "ProjRed|Transmission",


### PR DESCRIPTION
Fixes a startup crash if MrTJPCore is loaded after Project Red
