### PR TITLE
Oredictify many things.

### DIFF
--- a/src/mrtjp/projectred/core/CoreRecipes.java
+++ b/src/mrtjp/projectred/core/CoreRecipes.java
@@ -34,25 +34,25 @@ public class CoreRecipes
                 .$plus$eq((Output)new ItemOut(ProjectRedCore.itemDrawPlate()));
         b.registerResult();
 
-        /** Screw Driver **/
+        /** Screwdriver **/
         GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(ProjectRedCore.itemScrewdriver()),
                 "i  ",
                 " ib",
                 " bi",
-                'i', Items.iron_ingot,
-                'b', Colors.BLUE.getOreDict()
+                'i', "ingotIron",
+                'b', "dyeBlue"
         ));
 
-        /** Wire debugger **/
+        /** Wire Debugger **/
         GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(ProjectRedCore.itemWireDebugger()),
                 "a a",
                 "ber",
                 "bgr",
-                'a', REDINGOT().makeStack(),
-                'b', Colors.BLACK.getOreDict(),
-                'e', Items.emerald,
-                'r', Colors.RED.getOreDict(),
-                'g', Items.glowstone_dust
+                'a', "ingotRedAlloy",
+                'b', "dyeBlack",
+                'e', "gemEmerald",
+                'r', "dyeRed",
+                'g', "dustGlowstone"
                 ));
 
         /** Data Card **/
@@ -61,7 +61,7 @@ public class CoreRecipes
                 "prp",
                 "prp",
                 'p', Items.paper,
-                'r', Items.redstone
+                'r', "dustRedstone"
                 );
 
 
@@ -70,13 +70,13 @@ public class CoreRecipes
     private static void initPartRecipes()
     {
         /** Circuit Plate **/
-        GameRegistry.addSmelting(Blocks.stone, PLATE().makeStack(2), 0f);
+        GameRegistry.addSmelting("stone", PLATE().makeStack(2), 0f);
 
         /** Conductive Plate **/
         GameRegistry.addRecipe(CONDUCTIVEPLATE().makeStack(),
                 "r",
                 "p",
-                'r', Items.redstone,
+                'r', "dustRedstone",
                 'p', PLATE().makeStack()
                 );
 
@@ -85,7 +85,7 @@ public class CoreRecipes
                 " r ",
                 "rrr",
                 "ppp",
-                'r', Items.redstone,
+                'r', "dustRedstone",
                 'p', PLATE().makeStack()
                 );
 
@@ -102,7 +102,7 @@ public class CoreRecipes
                 "b",
                 "m",
                 "c",
-                'b', Blocks.stone,
+                'b', "stone",
                 'm', Blocks.redstone_torch,
                 'c', PLATE().makeStack()
                 );
@@ -156,10 +156,10 @@ public class CoreRecipes
                 " i ",
                 "scs",
                 "rcr",
-                'i', Items.iron_ingot,
-                's', Blocks.stone,
+                'i', "ingotIron",
+                's', "stone",
                 'c', COPPERCOIL().makeStack(),
-                'r', Items.redstone
+                'r', "dustRedstone"
                 );
 
         /** Copper Coil **/
@@ -172,14 +172,14 @@ public class CoreRecipes
         /** Iron Coil **/
         GameRegistry.addRecipe(IRONCOIL().makeStack(),
                 "cd",
-                'c', Items.iron_ingot,
+                'c', "ingotIron",
                 'd', new ItemStack(ProjectRedCore.itemDrawPlate(), 1, OreDictionary.WILDCARD_VALUE)
                 );
 
         /** Gold Coil **/
         GameRegistry.addRecipe(GOLDCOIL().makeStack(),
                 "cd",
-                'c', Items.gold_ingot,
+                'c', "ingotGold",
                 'd', new ItemStack(ProjectRedCore.itemDrawPlate(), 1, OreDictionary.WILDCARD_VALUE)
                 );
 
@@ -191,8 +191,8 @@ public class CoreRecipes
         for (int i = 0; i < ILLUMARS().size(); i++) {
             PartVal p = (PartVal)it.next();
             GameRegistry.addRecipe(new ShapelessOreRecipe(p.makeStack(),
-                    new ItemStack(Items.glowstone_dust),
-                    new ItemStack(Items.glowstone_dust),
+                    "dustGlowstone",
+                    "dustGlowstone",
                     Colors.get(i).getOreDict(),
                     Colors.get(i).getOreDict()
                     ));
@@ -220,8 +220,8 @@ public class CoreRecipes
                 "rrr",
                 "rir",
                 "rrr",
-                'r', Items.redstone,
-                'i', Items.iron_ingot
+                'r', "dustRedstone",
+                'i', "ingotIron"
                 );
 
         /** Sandy Coal Compound **/
@@ -229,7 +229,7 @@ public class CoreRecipes
                 "sss",
                 "scs",
                 "sss",
-                'c', Blocks.coal_block,
+                'c', "blockCoal",
                 's', Blocks.sand
                 );
 
@@ -238,7 +238,7 @@ public class CoreRecipes
                 "rrr",
                 "rsr",
                 "rrr",
-                'r', Items.redstone,
+                'r', "dustRedstone",
                 's', SILICON().makeStack()
                 );
 
@@ -247,7 +247,7 @@ public class CoreRecipes
                 "ggg",
                 "gsg",
                 "ggg",
-                'g', Items.glowstone_dust,
+                'g', "dustGlowstone",
                 's', SILICON().makeStack()
                 );
     }

--- a/src/mrtjp/projectred/exploration/ExplorationRecipes.java
+++ b/src/mrtjp/projectred/exploration/ExplorationRecipes.java
@@ -34,6 +34,10 @@ public class ExplorationRecipes
         OreDictionary.registerOre("oreRuby", OreDefs.ORERUBY().makeStack());
         OreDictionary.registerOre("oreSapphire", OreDefs.ORESAPPHIRE().makeStack());
         OreDictionary.registerOre("orePeridot", OreDefs.OREPERIDOT().makeStack());
+
+        OreDictionary.registerOre("blockRuby", DecorativeStoneDefs.RUBYBLOCK().makeStack());
+        OreDictionary.registerOre("blockSapphire", DecorativeStoneDefs.SAPPHIREBLOCK().makeStack());
+        OreDictionary.registerOre("blockPeridot", DecorativeStoneDefs.PERIDOTBLOCK().makeStack());
     }
 
     private static void initGemToolRecipes()
@@ -64,7 +68,7 @@ public class ExplorationRecipes
         addSwordRecipe(new ItemStack(ProjectRedExploration.itemPeridotSword()), "gemPeridot");
 
         /** Saw **/
-        addSawRecipe(new ItemStack(ProjectRedExploration.itemGoldSaw()), new ItemStack(Items.gold_ingot));
+        addSawRecipe(new ItemStack(ProjectRedExploration.itemGoldSaw()), "ingotGold");
         addSawRecipe(new ItemStack(ProjectRedExploration.itemRubySaw()), "gemRuby");
         addSawRecipe(new ItemStack(ProjectRedExploration.itemSapphireSaw()), "gemSapphire");
         addSawRecipe(new ItemStack(ProjectRedExploration.itemPeridotSaw()), "gemPeridot");
@@ -72,12 +76,12 @@ public class ExplorationRecipes
         /** Sickle **/
         addSickleRecipe(new ItemStack(ProjectRedExploration.itemWoodSickle()), "plankWood");
         addSickleRecipe(new ItemStack(ProjectRedExploration.itemStoneSickle()), new ItemStack(Items.flint));
-        addSickleRecipe(new ItemStack(ProjectRedExploration.itemIronSickle()), new ItemStack(Items.iron_ingot));
-        addSickleRecipe(new ItemStack(ProjectRedExploration.itemGoldSickle()), new ItemStack(Items.gold_ingot));
+        addSickleRecipe(new ItemStack(ProjectRedExploration.itemIronSickle()), "ingotIron");
+        addSickleRecipe(new ItemStack(ProjectRedExploration.itemGoldSickle()), "ingotGold");
         addSickleRecipe(new ItemStack(ProjectRedExploration.itemRubySickle()), "gemRuby");
         addSickleRecipe(new ItemStack(ProjectRedExploration.itemSapphireSickle()), "gemSapphire");
         addSickleRecipe(new ItemStack(ProjectRedExploration.itemPeridotSickle()), "gemPeridot");
-        addSickleRecipe(new ItemStack(ProjectRedExploration.itemDiamondSickle()), new ItemStack(Items.diamond));
+        addSickleRecipe(new ItemStack(ProjectRedExploration.itemDiamondSickle()), "gemDiamond");
 
     }
 
@@ -212,29 +216,29 @@ public class ExplorationRecipes
                 "xxx",
                 "xxx",
                 "xxx",
-                'x', PartDefs.RUBY().makeStack()
+                'x', "gemRuby"
                 );
         /** Sapphire block **/
         GameRegistry.addRecipe(DecorativeStoneDefs.SAPPHIREBLOCK().makeStack(),
                 "xxx",
                 "xxx",
                 "xxx",
-                'x', PartDefs.SAPPHIRE().makeStack()
+                'x', "gemSapphire"
                 );
         /** Peridot block **/
         GameRegistry.addRecipe(DecorativeStoneDefs.PERIDOTBLOCK().makeStack(),
                 "xxx",
                 "xxx",
                 "xxx",
-                'x', PartDefs.PERIDOT().makeStack()
+                'x', "gemPeridot"
                 );
 
         /** Ruby **/
-        GameRegistry.addShapelessRecipe(PartDefs.RUBY().makeStack(9), DecorativeStoneDefs.RUBYBLOCK().makeStack());
+        GameRegistry.addShapelessRecipe(PartDefs.RUBY().makeStack(9), "blockRuby");
         /** Sapphire **/
-        GameRegistry.addShapelessRecipe(PartDefs.SAPPHIRE().makeStack(9), DecorativeStoneDefs.SAPPHIREBLOCK().makeStack());
+        GameRegistry.addShapelessRecipe(PartDefs.SAPPHIRE().makeStack(9), "blockSapphire");
         /** Peridot **/
-        GameRegistry.addShapelessRecipe(PartDefs.PERIDOT().makeStack(9), DecorativeStoneDefs.PERIDOTBLOCK().makeStack());
+        GameRegistry.addShapelessRecipe(PartDefs.PERIDOT().makeStack(9), "blockPeridot");
 
         /** Walls **/
         for (int i = 0; i < DecorativeStoneDefs.values().size(); i++)

--- a/src/mrtjp/projectred/illumination/IlluminationRecipes.scala
+++ b/src/mrtjp/projectred/illumination/IlluminationRecipes.scala
@@ -23,16 +23,16 @@ object IlluminationRecipes
                 "gIg",
                 "gIg",
                 "gtg",
-                'g':JC, Blocks.glass_pane,
+                'g':JC, "paneGlassColorless",
                 'I':JC, PartDefs.ILLUMARS.toSeq(i).makeStack,
-                't':JC, Items.redstone
+                't':JC, "dustRedstone"
             )
 
             GameRegistry.addRecipe(new ItemStack(ProjectRedIllumination.blockLamp, 1, i+16),
                 "gIg",
                 "gIg",
                 "gtg",
-                'g':JC, Blocks.glass_pane,
+                'g':JC, "paneGlassColorless",
                 'I':JC, PartDefs.ILLUMARS.toSeq(i).makeStack,
                 't':JC, Blocks.redstone_torch
             )
@@ -46,18 +46,18 @@ object IlluminationRecipes
                 "GIG",
                 "PRP",
                 'P':JC, PartDefs.PLATE.makeStack,
-                'N':JC, Items.gold_nugget,
-                'G':JC, Blocks.glass_pane,
+                'N':JC, "nuggetGold",
+                'G':JC, "paneGlassColorless",
                 'I':JC, PartDefs.ILLUMARS.toSeq(i).makeStack,
-                'R':JC, Items.redstone
+                'R':JC, "dustRedstone"
             )
             GameRegistry.addRecipe(LightObjLantern.makeInvStack(i),
                 "PNP",
                 "GIG",
                 "PRP",
                 'P':JC, PartDefs.PLATE.makeStack,
-                'N':JC, Items.gold_nugget,
-                'G':JC, Blocks.glass_pane,
+                'N':JC, "nuggetGold",
+                'G':JC, "paneGlassColorless",
                 'I':JC, PartDefs.ILLUMARS.toSeq(i).makeStack,
                 'R':JC, Blocks.redstone_torch
             )
@@ -84,7 +84,7 @@ object IlluminationRecipes
                 "CCC", "CIC", "NPN",
                 'C':JC, Blocks.iron_bars,
                 'I':JC, PartDefs.ILLUMARS.toSeq(i).makeStack,
-                'N':JC, Items.gold_nugget,
+                'N':JC, "nuggetGold",
                 'P':JC, PartDefs.CONDUCTIVEPLATE.makeStack
             )
 
@@ -92,7 +92,7 @@ object IlluminationRecipes
                 "CCC", "CIC", "NPN",
                 'C':JC, Blocks.iron_bars,
                 'I':JC, PartDefs.ILLUMARS.toSeq(i).makeStack,
-                'N':JC, Items.gold_nugget,
+                'N':JC, "nuggetGold",
                 'P':JC, PartDefs.CATHODE.makeStack
             )
         }
@@ -122,14 +122,14 @@ object IlluminationRecipes
         {
             GameRegistry.addRecipe(LightObjFixture.makeStack(i),
                 "ggg", "gIg", "pPp",
-                'g':JC, Blocks.glass_pane,
+                'g':JC, "paneGlassColorless",
                 'I':JC, PartDefs.ILLUMARS.toSeq(i).makeStack,
                 'p':JC, PartDefs.PLATE.makeStack,
                 'P':JC, PartDefs.CONDUCTIVEPLATE.makeStack
             )
             GameRegistry.addRecipe(LightObjFixture.makeInvStack(i),
                 "ggg", "gIg", "pPp",
-                'g':JC, Blocks.glass_pane,
+                'g':JC, "paneGlassColorless",
                 'I':JC, PartDefs.ILLUMARS.toSeq(i).makeStack,
                 'p':JC, PartDefs.PLATE.makeStack,
                 'P':JC, PartDefs.CATHODE.makeStack

--- a/src/mrtjp/projectred/integration/IntegrationRecipes.java
+++ b/src/mrtjp/projectred/integration/IntegrationRecipes.java
@@ -243,7 +243,7 @@ public class IntegrationRecipes
                 "LLL",
                 "PWP",
                 'P', PartDefs.PLATE().makeStack(),
-                'L', new ItemStack(Items.dye, 1, Colors.BLUE.dyeId()),
+                'L', "dyeBlue",
                 'W', PartDefs.CONDUCTIVEPLATE().makeStack()
                 );
 
@@ -253,7 +253,7 @@ public class IntegrationRecipes
                 "SSS",
                 "PWP",
                 'P', PartDefs.PLATE().makeStack(),
-                'S', Items.slime_ball,
+                'S', "slimeball",
                 'W', PartDefs.CONDUCTIVEPLATE().makeStack()
                 );
 
@@ -306,7 +306,7 @@ public class IntegrationRecipes
                 "PWP",
                 'W', PartDefs.CONDUCTIVEPLATE().makeStack(),
                 'C', PartDefs.CATHODE().makeStack(),
-                'Q', Items.quartz,
+                'Q', "gemQuartz",
                 'P', PartDefs.PLATE().makeStack()
                 );
 

--- a/src/mrtjp/projectred/transportation/TransportationRecipes.scala
+++ b/src/mrtjp/projectred/transportation/TransportationRecipes.scala
@@ -30,8 +30,8 @@ object TransportationRecipes
         /** Item Transport pipe **/
         GameRegistry.addRecipe(PipeDefs.BASIC.makeStack(16),
             "sgs",
-            'g':JC, Blocks.glass_pane,
-            's':JC, Blocks.stone
+            'g':JC, "paneGlassColorless",
+            's':JC, "stone"
         )
 
         /** Routed Junction pipe **/
@@ -42,8 +42,8 @@ object TransportationRecipes
             'R':JC, PartDefs.REDILLUMAR.makeStack,
             'r':JC, PartDefs.INFUSEDSILICON.makeStack,
             'G':JC, PartDefs.GREENILLUMAR.makeStack,
-            'd':JC, Items.diamond,
-            'g':JC, Blocks.glass_pane
+            'd':JC, "gemDiamond",
+            'g':JC, "paneGlassColorless"
         )
 
         /** Routed Interface Pipe **/
@@ -51,31 +51,31 @@ object TransportationRecipes
             "rgr",
             "gjg",
             "rgr",
-            'g':JC, Items.gold_nugget,
+            'g':JC, "nuggetGold",
             'j':JC, PipeDefs.ROUTEDJUNCTION.makeStack,
-            'r':JC, Items.redstone
+            'r':JC, "dustRedstone"
         )
 
         /** Routed Crafting Pipe **/
         GameRegistry.addRecipe(PipeDefs.ROUTEDCRAFTING.makeStack,
             "rgr", "rjr", "rgr",
-            'r':JC, Items.redstone,
-            'g':JC, Items.glowstone_dust,
+            'r':JC, "dustRedstone",
+            'g':JC, "dustGlowstone",
             'j':JC, PipeDefs.ROUTEDJUNCTION.makeStack
         )
 
         /** Routed Request Pipe **/
         GameRegistry.addRecipe(PipeDefs.ROUTEDREQUEST.makeStack,
             "rdr", "rjr", "rdr",
-            'r':JC, Items.redstone,
-            'd':JC, Items.diamond,
+            'r':JC, "dustRedstone",
+            'd':JC, "gemDiamond",
             'j':JC, PipeDefs.ROUTEDJUNCTION.makeStack
         )
 
         /** Routed Extension Pipe **/
         GameRegistry.addRecipe(PipeDefs.ROUTEDEXTENSION.makeStack,
             " r ", "rjr", " r ",
-            'r':JC, Items.redstone,
+            'r':JC, "dustRedstone",
             'j':JC, PipeDefs.ROUTEDJUNCTION.makeStack
         )
 
@@ -98,57 +98,57 @@ object TransportationRecipes
         /** Null chip **/
         GameRegistry.addRecipe(PartDefs.NULLROUTINGCHIP.makeStack,
             "gpp", "grr", "g  ",
-            'g':JC, Items.gold_nugget,
+            'g':JC, "nuggetGold",
             'p':JC, Items.paper,
-            'r':JC, Items.redstone
+            'r':JC, "dustRedstone"
         )
 
         /** Item Responder **/
         addChipRecipe(RoutingChipDefs.ITEMRESPONDER.makeStack,
-            Items.iron_ingot, Items.redstone, Items.redstone,
+            "ingotIron", "dustRedstone", "dustRedstone",
             PartDefs.ORANGEILLUMAR.makeStack,
             PartDefs.ORANGEILLUMAR.makeStack)
 
         /** Dynamic Item Responder **/
         addChipRecipe(RoutingChipDefs.DYNAMICITEMRESPONDER.makeStack,
-            Items.iron_ingot, Items.redstone,
+            "ingotIron", "dustRedstone",
             PartDefs.CYANILLUMAR.makeStack,
             PartDefs.ORANGEILLUMAR.makeStack,
             PartDefs.ORANGEILLUMAR.makeStack)
 
         /** Item Overflow Responder **/
         addChipRecipe(RoutingChipDefs.ITEMOVERFLOWRESPONDER.makeStack,
-            Items.iron_ingot, Items.redstone, Items.redstone,
+            "ingotIron", "dustRedstone", "dustRedstone",
             PartDefs.GREENILLUMAR.makeStack,
             PartDefs.GREENILLUMAR.makeStack)
 
         /** Item Terminator **/
         addChipRecipe(RoutingChipDefs.ITEMTERMINATOR.makeStack,
-            Items.iron_ingot, Items.redstone, Items.redstone,
+            "ingotIron", "dustRedstone", "dustRedstone",
             PartDefs.PURPLEILLUMAR.makeStack,
             PartDefs.GREYILLUMAR.makeStack)
 
         /** Item Extractor **/
         addChipRecipe(RoutingChipDefs.ITEMEXTRACTOR.makeStack,
-            Items.iron_ingot, Items.redstone, Items.redstone,
+            "ingotIron", "dustRedstone", "dustRedstone",
             PartDefs.CYANILLUMAR.makeStack,
             PartDefs.CYANILLUMAR.makeStack)
 
         /** Item Broadcaster **/
         addChipRecipe(RoutingChipDefs.ITEMBROADCASTER.makeStack,
-            Items.gold_ingot, Items.redstone, Items.redstone,
+            "ingotGold", "dustRedstone", "dustRedstone",
             PartDefs.MAGENTAILLUMAR.makeStack,
             PartDefs.MAGENTAILLUMAR.makeStack)
 
         /** Item Stock Keeper **/
         addChipRecipe(RoutingChipDefs.ITEMSTOCKKEEPER.makeStack,
-            Items.diamond, Items.redstone, Items.redstone,
+            "gemDiamond", "dustRedstone", "dustRedstone",
             PartDefs.BLUEILLUMAR.makeStack,
             PartDefs.BLUEILLUMAR.makeStack)
 
         /** Item Crafting **/
         addChipRecipe(RoutingChipDefs.ITEMCRAFTING.makeStack,
-            Items.glowstone_dust, Items.redstone, Items.glowstone_dust,
+            "dustGlowstone", "dustRedstone", "dustGlowstone",
             PartDefs.LIMEILLUMAR.makeStack,
             PartDefs.LIMEILLUMAR.makeStack)
 
@@ -170,28 +170,28 @@ object TransportationRecipes
         /** Router Utility **/
         GameRegistry.addRecipe(new ItemStack(ProjectRedTransportation.itemRouterUtility),
             "  r", "iei", "iii",
-            'r':JC, Items.redstone,
-            'i':JC, Items.iron_ingot,
-            'e':JC, Items.emerald)
+            'r':JC, "dustRedstone",
+            'i':JC, "ingotIron",
+            'e':JC, "gemEmerald")
 
         /** Null Upgrade **/
         GameRegistry.addRecipe(PartDefs.NULLUPGRADECHIP.makeStack,
             "prp", "rrr", "prp",
-            'p':JC, Items.paper, 'r':JC, Items.redstone)
+            'p':JC, Items.paper, 'r':JC, "dustRedstone")
 
         /** LX **/
         GameRegistry.addRecipe(PartDefs.CHIPUPGRADE_LX.makeStack,
             "rrr", " ng", "r r",
-            'r':JC, Items.redstone,
+            'r':JC, "dustRedstone",
             'n':JC, PartDefs.NULLUPGRADECHIP.makeStack,
-            'g':JC, Items.gold_nugget)
+            'g':JC, "nuggetGold")
 
         /** RX **/
         GameRegistry.addRecipe(PartDefs.CHIPUPGRADE_RX.makeStack,
             "r r", "gn ", "rrr",
-            'r':JC, Items.redstone,
+            'r':JC, "dustRedstone",
             'n':JC, PartDefs.NULLUPGRADECHIP.makeStack,
-            'g':JC, Items.gold_nugget)
+            'g':JC, "nuggetGold")
 
         /** LY **/
         GameRegistry.addRecipe(PartDefs.CHIPUPGRADE_LY.makeStack,
@@ -208,16 +208,16 @@ object TransportationRecipes
         /** LZ **/
         GameRegistry.addRecipe(PartDefs.CHIPUPGRADE_LZ.makeStack,
             "r r", " n ", "rer",
-            'r':JC, Items.redstone,
+            'r':JC, "dustRedstone",
             'n':JC, PartDefs.CHIPUPGRADE_LY.makeStack,
-            'e':JC, Items.emerald)
+            'e':JC, "gemEmerald")
 
         /** RZ **/
         GameRegistry.addRecipe(PartDefs.CHIPUPGRADE_RZ.makeStack,
             "r r", " n ", "rer",
-            'r':JC, Items.redstone,
+            'r':JC, "dustRedstone",
             'n':JC, PartDefs.CHIPUPGRADE_RY.makeStack,
-            'e':JC, Items.emerald)
+            'e':JC, "gemEmerald")
     }
 
     def initMiscRecipes()


### PR DESCRIPTION
Updates many recipes to use oredict entries except for `Items.stick` → `"stickWood"` which is covered by #613.
Also adds oredict entries for the three gem storage blocks.
