### PR TITLE
Force CCC version for NEI

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,12 @@ configurations {
     deployerJars
 }
 
+configurations.all {
+    resolutionStrategy {
+        force "codechicken:CodeChickenCore:${config.mc.version}-${config.ccc.version}:dev"
+    }
+}
+
 dependencies {
     deployerJars "org.apache.maven.wagon:wagon-ftp:2.2"
 

--- a/build.properties
+++ b/build.properties
@@ -1,10 +1,11 @@
 mod.version=4.5.15
 
 mc.version=1.7.10
-forge.version=10.13.2.1277
+forge.version=10.13.2.1291
 
 mrtjp.version=1.0.5.11
-ccl.version=1.1.1.110
+ccl.version=1.1.3.127
+ccc.version=1.0.4.35
 fmp.version=1.1.1.320
 
 nei.version=1.0.4.83


### PR DESCRIPTION
Fixes error with NEI looking for 1.0.4 but getting 1.0.2. Doesn't break anything else.