### PR TITLE
Updated MrTJPCore to version 1.0.9.22.

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -3,7 +3,7 @@ mod.version=4.7.0pre2
 mc.version=1.7.10
 forge.version=10.13.3.1399-1.7.10
 
-mrtjp.version=1.0.9.19
+mrtjp.version=1.0.9.22
 ccl.version=1.1.3.136
 fmp.version=1.2.0.344
 


### PR DESCRIPTION
Updated MrTJPCore to version 1.0.9.22.

This solved the crash issue we've been experiencing in #814, #815 and #817