### PR TITLE
fixed? routers array getting filled twice.

### DIFF
--- a/src/mrtjp/projectred/transportation/router.scala
+++ b/src/mrtjp/projectred/transportation/router.scala
@@ -40,6 +40,10 @@ object RouterServices
         routers synchronized
             {
                 for (r <- routers) if (r != null && r.getParent == holder) return r
+                
+                val r0 = getRouter(getIPforUUID(uu))
+                if(r0!=null ) return r0
+                
                 val r = Router(uu, holder)
 
                 val newLease = r.getIPAddress


### PR DESCRIPTION
This fixes the crafting extension chips not working