### PR TITLE
Fix typo in PowerConductor docs

### DIFF
--- a/src/mrtjp/projectred/core/powertraits.scala
+++ b/src/mrtjp/projectred/core/powertraits.scala
@@ -44,7 +44,7 @@ trait IPowerConnectable extends IConnectable
 /**
  * Object held by conducting power tiles, self managed through
  * TPowerConnectable. This model of electrical flow loosely emulates
- * phisics of real world electrical flow in a series circuit.
+ * physics of real world electrical flow in a series circuit.
  * @param parent The "actual" conductor (as in, the tile).
  * @param ids The possible connections to other conductors
  *            this can make.


### PR DESCRIPTION
Just a small thing I noticed when reading through the source.
