### PR TITLE
Fix dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,9 @@ buildscript {
             name = "covers1624"
             url = "http://mavenmirror.covers1624.net/"
         }
+        maven {
+            url "http://files.minecraftforge.net/maven"
+        }
     }
     dependencies {
         classpath 'net.minecraftforge.gradle:ForgeGradle:2.2-SNAPSHOT'


### PR DESCRIPTION
```
A problem occured configuring root project 'ProjectRed'.
> Could not resolve all dependencies for configuration ':classpath'.
    > Could not find net.minecraftforge:fernflower:2.0-SNAPSHOT.
```

After a quick search, I found that minecraftforge's own maven repository has the required file/s so I added the URL to the repositories