### PR TITLE
Speed up WireNet.mapChannelForPoint

### DIFF
--- a/src/mrtjp/projectred/fabrication/wiretileabstracts.scala
+++ b/src/mrtjp/projectred/fabrication/wiretileabstracts.scala
@@ -269,7 +269,7 @@ class WireNet(ic:ICTileMapContainer, p:Point, mask:Int) extends IWireNet
         }
     }
 
-    def mapChannelForPoint(p:Point, r:Int):Seq[(Point, Int)] =
+    def mapChannelForPoint(p:Point, r:Int):Set[(Point, Int)] =
     {
         val (cmask, pmask) = ic.getTile(p) match {
             case w:IWireICTile =>
@@ -280,7 +280,7 @@ class WireNet(ic:ICTileMapContainer, p:Point, mask:Int) extends IWireNet
         if (cmask == 0) return null
         if (pmask == 0) return null
 
-        def iterate(open:Seq[CSearchNode2], closed:Set[CSearchNode2] = Set(), points:Seq[(Point, Int)] = Seq()):Seq[(Point, Int)] = open match {
+        def iterate(open:Seq[CSearchNode2], closed:Set[CSearchNode2] = Set(), points:Set[(Point, Int)] = Set()):Set[(Point, Int)] = open match {
             case Seq() => points
             case Seq(next, rest@_*) => ic.getTile(next.pos) match {
                 case w:IWireICTile =>
@@ -299,7 +299,7 @@ class WireNet(ic:ICTileMapContainer, p:Point, mask:Int) extends IWireNet
                         }
 
                     }
-                    iterate(rest ++ upNext.result(), closed + next, (points :+ (next.pos, next.r)).distinct)
+                    iterate(rest ++ upNext.result(), closed + next, points + ((next.pos, next.r)))
             }
         }
 


### PR DESCRIPTION
This causes the massive amount of time spent on WireNet.mapChannelForPoint in my world to decrease to about 40 seconds instead of multiple minutes. These times are measures with 64 of the blueprints in #1374. So, at the same time, a lot yet not a lot.

Now, I think there's still room for improvement. The next largest bottlenecks are:
 - `open.contains(r)` -- open is a Seq, this may be faster by using a set instead. 13.9 seconds
   - you appear to use open as a queue though, I'm not sure if iterating on it out of order would be fine or not.
 - `next --> (r, newCMask, newPMask)` -- not sure what this does/is for. 10.6 seconds
 - `closed.contains(r)` -- apparently using up 3 seconds (i think it's the only set with contains being called on it in here), not sure there's much we can do about that, other than optimizing logic?