### PR TITLE
Fix indeterministic compile of ICs

### DIFF
--- a/src/mrtjp/projectred/fabrication/SimLinker.scala
+++ b/src/mrtjp/projectred/fabrication/SimLinker.scala
@@ -24,7 +24,7 @@ trait ISEGateTile extends ISETile
 
 trait IWireNet
 {
-    val points:scala.collection.Set[(Point, Int)]
+    val points:scala.collection.mutable.Seq[(Point, Int)]
 
     def allocateRegisters(linker:ISELinker)
 

--- a/src/mrtjp/projectred/fabrication/SimLinker.scala
+++ b/src/mrtjp/projectred/fabrication/SimLinker.scala
@@ -132,8 +132,8 @@ trait ISELinker
 
 object ISELinker
 {
-    def linkFromMap(map:ISETileMap, icDelegate: ISEICDelegate, logger:ISEStatLogger):SEIntegratedCircuit =
-        SELinker.linkFromMap(map, icDelegate, logger)
+    def linkFromMap(map:ISETileMap, logger:ISEStatLogger):SEIntegratedCircuit =
+        SELinker.linkFromMap(map, logger)
 }
 
 private class SELinker(logger:ISEStatLogger) extends ISELinker
@@ -253,10 +253,12 @@ private class SELinker(logger:ISEStatLogger) extends ISELinker
 
 private object SELinker
 {
-    def linkFromMap(map:ISETileMap, icDelegate:ISEICDelegate, logger:ISEStatLogger):SEIntegratedCircuit =
+    def linkFromMap(map:ISETileMap, logger:ISEStatLogger):SEIntegratedCircuit =
     {
         val linker = new SELinker(logger)
         import linker._
+
+        val startTime = System.currentTimeMillis()
 
         logger.logInfo("Adding SFRs...")
         //Add all SFRs
@@ -340,11 +342,18 @@ private object SELinker
             g.declareOperations(linker) //from gates
 
         logger.logInfo("Creating IC...")
-        new SEIntegratedCircuit(
+        val ic = new SEIntegratedCircuit(
             registers.toSeq,
             gates.toSeq,
-            regDependents.toMap,
-            icDelegate
+            regDependents.toMap
         )
+
+        logger.logInfo("Computing initial signals...")
+        ic.computeAll()
+
+        val endTime = System.currentTimeMillis()
+
+        logger.logInfo(s"Completed linking in ${endTime-startTime} ms.")
+        ic
     }
 }

--- a/src/mrtjp/projectred/fabrication/buttonpart.scala
+++ b/src/mrtjp/projectred/fabrication/buttonpart.scala
@@ -107,7 +107,7 @@ class ButtonICTile extends ICTile with TICTileAcquisitions with IRedwireICGate w
         for (r <- 0 until 4)
             editor.simEngineContainer.simEngine.queueRegVal[Byte](outputRegs(r), if (on) 1 else 0)
 
-        editor.simEngineContainer.simEngine.repropagate()
+        editor.simEngineContainer.simEngine.propagate(editor.simEngineContainer)
     }
 
     override def onRegistersChanged(regIDs:Set[Int]){} //we dont care if other registers change

--- a/src/mrtjp/projectred/fabrication/fmpgatepart.scala
+++ b/src/mrtjp/projectred/fabrication/fmpgatepart.scala
@@ -108,11 +108,8 @@ class ICGateLogic(gate:ICGatePart) extends RedstoneGateLogic[ICGatePart] with TB
     {
         tmap.loadTiles(tag)
 
-        sim.propagateSilently = true
         sim.recompileSimulation(tmap)
-        sim.propagateAll()
         sim.loadSimState(tag)
-        sim.propagateSilently = false
 
         val (ri0, ro0, bi0, bo0) = ICGateLogic.unpackIO(tag.getShort("masks"))
         ri = ri0; ro = ro0; bi = bi0; bo = bo0
@@ -298,10 +295,7 @@ object ICGateLogic
             logic.tmap.name = "ERROR: invalid"
         }
 
-        logic.sim.propagateSilently = true
         logic.sim.recompileSimulation(logic.tmap)
-        logic.sim.propagateAll()
-        logic.sim.propagateSilently = false
     }
 
     def packIO(ri:Int, ro:Int, bi:Int, bo:Int) = ri|ro<<4|bi<<8|bo<<12

--- a/src/mrtjp/projectred/fabrication/gatetile_combo.scala
+++ b/src/mrtjp/projectred/fabrication/gatetile_combo.scala
@@ -162,6 +162,7 @@ object OR extends ComboGateTileLogic
         val outID = outputs(0)
 
         new ISEGate {
+            private val serialVersionUID = 1L
             override def compute(ic:SEIntegratedCircuit) {
                 ic.queueRegVal[Byte](outID, if (inIDs.exists(ic.getRegVal(_) != 0)) 1 else 0)
             }
@@ -202,6 +203,7 @@ object NOT extends ComboGateTileLogic
         val outIDs = outputs.filter(_ != -1).toSeq
 
         new ISEGate {
+            private val serialVersionUID = 1L
             override def compute(ic:SEIntegratedCircuit) {
                 val outVal = (if (ic.getRegVal(inID) != 0) 0 else 1).toByte
                 outIDs.foreach(ic.queueRegVal[Byte](_, outVal))
@@ -223,6 +225,7 @@ object AND extends ComboGateTileLogic
         val outID = outputs(0)
 
         new ISEGate {
+            private val serialVersionUID = 1L
             override def compute(ic:SEIntegratedCircuit) {
                 ic.queueRegVal[Byte](outID, if (inIDs.forall(ic.getRegVal(_) != 0)) 1 else 0)
             }
@@ -243,6 +246,7 @@ object NAND extends ComboGateTileLogic
         val outID = outputs(0)
 
         new ISEGate {
+            private val serialVersionUID = 1L
             override def compute(ic:SEIntegratedCircuit) {
                 ic.queueRegVal[Byte](outID, if (inIDs.forall(ic.getRegVal(_) != 0)) 0 else 1)
             }
@@ -262,6 +266,7 @@ object XOR extends ComboGateTileLogic
         val outID = outputs(0)
 
         new ISEGate {
+            private val serialVersionUID = 1L
             override def compute(ic:SEIntegratedCircuit) {
                 ic.queueRegVal[Byte](outID, if (ic.getRegVal(in1) != ic.getRegVal(in2)) 1 else 0)
             }
@@ -281,6 +286,7 @@ object XNOR extends ComboGateTileLogic
         val outID = outputs(0)
 
         new ISEGate {
+            private val serialVersionUID = 1L
             override def compute(ic:SEIntegratedCircuit) {
                 ic.queueRegVal[Byte](outID, if (ic.getRegVal(in1) == ic.getRegVal(in2)) 1 else 0)
             }
@@ -302,6 +308,7 @@ object Buffer extends ComboGateTileLogic
         val outIDs = outputs.filter(_ != -1).toSeq
 
         new ISEGate {
+            private val serialVersionUID = 1L
             override def compute(ic:SEIntegratedCircuit) {
                 val in = ic.getRegVal[Byte](inID)
                 outIDs.foreach(ic.queueRegVal[Byte](_, in))
@@ -321,6 +328,7 @@ object Multiplexer extends ComboGateTileLogic
         val outID = outputs(0)
 
         new ISEGate {
+            private val serialVersionUID = 1L
             override def compute(ic:SEIntegratedCircuit) {
                 ic.queueRegVal[Byte](outID,
                     if (ic.getRegVal[Byte](inIDs(2)) != 0)

--- a/src/mrtjp/projectred/fabrication/gatetile_io.scala
+++ b/src/mrtjp/projectred/fabrication/gatetile_io.scala
@@ -160,6 +160,7 @@ abstract class IOGateTileLogic(val gate:IOGateICTile) extends RedstoneGateTileLo
     def getOutputOp(input:Int, output:Int):ISEGate =
     {
         new ISEGate {
+            private val serialVersionUID = 1L
             override def compute(ic:SEIntegratedCircuit) {
                 ic.queueRegVal[Byte](output, if (ic.getRegVal(input) != 0) 1 else 0)
             }

--- a/src/mrtjp/projectred/fabrication/gatetile_seq.scala
+++ b/src/mrtjp/projectred/fabrication/gatetile_seq.scala
@@ -218,6 +218,7 @@ class Pulse(gate:SequentialGateICTile) extends SequentialGateTileLogic(gate)
         val schdTimeReg = this.schdTimeReg
 
         val calculation = new ISEGate {
+            private val serialVersionUID = 1L
             override def compute(ic:SEIntegratedCircuit) {
                 ic.getRegVal[Byte](stateReg) match {
                     case 0 => //Wait for high input state
@@ -291,6 +292,7 @@ class Repeater(gate:SequentialGateICTile) extends SequentialGateTileLogic(gate)
         val delay = delays(gate.shape)
 
         val calculation = new ISEGate {
+            private val serialVersionUID = 1L
             override def compute(ic:SEIntegratedCircuit) {
 
                 def inputHi = ic.getRegVal[Byte](inputReg) != 0
@@ -374,6 +376,7 @@ class Randomizer(gate:SequentialGateICTile) extends SequentialGateTileLogic(gate
         val timeStartReg = this.timeStartReg
 
         val calculation = new ISEGate {
+            private val serialVersionUID = 1L
             override def compute(ic:SEIntegratedCircuit) {
 
                 def inputHi = ic.getRegVal[Byte](inputReg) != 0
@@ -462,6 +465,7 @@ class SRLatch(gate:SequentialGateICTile) extends SequentialGateTileLogic(gate)
         val stateReg = this.stateReg
 
         val calculation = new ISEGate {
+            private val serialVersionUID = 1L
             val rand = new Random()
 
             override def compute(ic:SEIntegratedCircuit) {
@@ -569,6 +573,7 @@ class ToggleLatch(gate:SequentialGateICTile) extends SequentialGateTileLogic(gat
         val defState = gate.shape
 
         val calculation = new ISEGate {
+            private val serialVersionUID = 1L
             override def compute(ic:SEIntegratedCircuit) {
                 def enterAState() {
                     ic.queueRegVal[Byte](stateReg, 0)
@@ -744,6 +749,7 @@ class TransparentLatch(gate:SequentialGateICTile) extends SequentialGateTileLogi
         val stateReg = this.stateReg
 
         val calculation = new ISEGate {
+            private val serialVersionUID = 1L
             override def compute(ic:SEIntegratedCircuit) {
 
                 def dataWrHi = ic.getRegVal[Byte](wrEnableReg) != 0
@@ -818,6 +824,7 @@ class Timer(gate:SequentialGateICTile) extends SequentialGateTileLogic(gate) wit
         val timerMax = getTimerMax
 
         val calculation = new ISEGate {
+            private val serialVersionUID = 1L
             override def compute(ic:SEIntegratedCircuit) {
                 val sysTime = ic.getRegVal[Long](REG_SYSTIME)
                 val pointerVal = sysTime-ic.getRegVal[Long](timerStartReg) match {
@@ -957,6 +964,7 @@ class Sequencer(gate:SequentialGateICTile) extends SequentialGateTileLogic(gate)
         val reflect = gate.shape == 1
 
         val calculation = new ISEGate {
+            private val serialVersionUID = 1L
             override def compute(ic:SEIntegratedCircuit) {
                 val quadron = ic.getRegVal[Long](REG_SYSTIME)%(timerMax*4)/timerMax
                 ic.queueRegVal[Byte](output1Reg, if (quadron == 0) 1 else 0)
@@ -1135,6 +1143,7 @@ class Counter(gate:SequentialGateICTile) extends SequentialGateTileLogic(gate) w
         val decrVal = decr
 
         val calculation = new ISEGate {
+            private val serialVersionUID = 1L
             override def compute(ic:SEIntegratedCircuit) {
 
                 var counterVal = ic.getRegVal[Int](valueReg)
@@ -1239,6 +1248,7 @@ class StateCell(gate:SequentialGateICTile) extends SequentialGateTileLogic(gate)
         val timerMax = getTimerMax
 
         val calculation = new ISEGate {
+            private val serialVersionUID = 1L
             override def compute(ic:SEIntegratedCircuit)
             {
                 val sysTime = ic.getRegVal[Long](REG_SYSTIME)
@@ -1374,6 +1384,7 @@ class Synchronizer(gate:SequentialGateICTile) extends SequentialGateTileLogic(ga
         val timerStartReg = this.timerStartReg
 
         val calculation = new ISEGate {
+            private val serialVersionUID = 1L
             override def compute(ic:SEIntegratedCircuit)
             {
                 val inputMask = (if (ic.getRegVal[Byte](input2Reg) != 0) 2 else 0) | (if (ic.getRegVal[Byte](input1Reg) != 0) 1 else 0)

--- a/src/mrtjp/projectred/fabrication/guiicworkbench.scala
+++ b/src/mrtjp/projectred/fabrication/guiicworkbench.scala
@@ -762,7 +762,7 @@ class GuiICWorkbench(val tile:TileICWorkbench) extends NodeGui(330, 256)
                 val nic = new NewICNode
                 nic.position = Point(size/2)-Point(nic.size/2)
                 nic.completionDelegate = {() =>
-                    val ic = new ICTileMapEditor(null)
+                    val ic = new ICTileMapEditor(null) //TODO Change this mechanism to not send entire blank IC desc
                     ic.tileMapContainer.name = nic.getName
                     ic.tileMapContainer.size = nic.selectedBoardSize*16
                     tile.sendNewICToServer(ic)

--- a/src/mrtjp/projectred/fabrication/ictileeditor.scala
+++ b/src/mrtjp/projectred/fabrication/ictileeditor.scala
@@ -176,8 +176,6 @@ class ICTileMapEditor(val network:IICTileEditorNetwork) extends IICSimEngineCont
 
     private var scheduledTicks = MMap[Point, Long]()
 
-    recompileSchematic()
-
     tileMapContainer.tilesLoadedDelegate = {() =>
         simNeedsRefresh = true
         for (tile <- tileMapContainer.tiles.values)

--- a/src/mrtjp/projectred/fabrication/ictileeditor.scala
+++ b/src/mrtjp/projectred/fabrication/ictileeditor.scala
@@ -176,9 +176,7 @@ class ICTileMapEditor(val network:IICTileEditorNetwork) extends IICSimEngineCont
 
     private var scheduledTicks = MMap[Point, Long]()
 
-    simEngineContainer.propagateSilently = true
     recompileSchematic()
-    simEngineContainer.propagateSilently = false
 
     tileMapContainer.tilesLoadedDelegate = {() =>
         simNeedsRefresh = true
@@ -200,10 +198,8 @@ class ICTileMapEditor(val network:IICTileEditorNetwork) extends IICSimEngineCont
         clear()
         tileMapContainer.loadTiles(tag)
 
-        simEngineContainer.propagateSilently = true
         recompileSchematic()
         simEngineContainer.loadSimState(tag)
-        simEngineContainer.propagateSilently = false
     }
 
     def writeDesc(out:MCDataOutput)
@@ -429,7 +425,6 @@ class ICTileMapEditor(val network:IICTileEditorNetwork) extends IICSimEngineCont
         simNeedsRefresh = false
         simEngineContainer.delegate = this
         simEngineContainer.recompileSimulation(tileMapContainer)
-        simEngineContainer.propagateAll()
     }
 
     override def registersDidChange(registers:Set[Int])

--- a/src/mrtjp/projectred/fabrication/leverpart.scala
+++ b/src/mrtjp/projectred/fabrication/leverpart.scala
@@ -78,7 +78,7 @@ class LeverICTile extends ICTile with TICTileAcquisitions with IRedwireICGate wi
     {
         for (r <- 0 until 4)
             editor.simEngineContainer.simEngine.queueRegVal[Byte](outputRegs(r), if (on) 1 else 0)
-        editor.simEngineContainer.simEngine.repropagate()
+        editor.simEngineContainer.simEngine.propagate(editor.simEngineContainer)
     }
 
     override def onRegistersChanged(regIDs:Set[Int]){} //we dont care if other registers change

--- a/src/mrtjp/projectred/fabrication/opwires.scala
+++ b/src/mrtjp/projectred/fabrication/opwires.scala
@@ -150,7 +150,7 @@ class OpInsulatedWire(colour:Int) extends OpWire
     }
 
     @SideOnly(Side.CLIENT)
-    override def getOpName = EnumColour.values()(colour&0xFF).name+" Insulated wire"
+    override def getOpName = EnumColour.values()(colour&0xFF).getLocalizedName+" Insulated wire"
 }
 
 class OpBundledCable(colour:Int) extends OpWire
@@ -179,5 +179,5 @@ class OpBundledCable(colour:Int) extends OpWire
     }
 
     @SideOnly(Side.CLIENT)
-    override def getOpName = (if (colour != -1) EnumColour.values()(colour&0xFF).name+" " else "")+"Bundled cable"
+    override def getOpName = (if (colour != -1) EnumColour.values()(colour&0xFF).getLocalizedName+" " else "")+"Bundled cable"
 }

--- a/src/mrtjp/projectred/fabrication/wiretileabstracts.scala
+++ b/src/mrtjp/projectred/fabrication/wiretileabstracts.scala
@@ -10,7 +10,8 @@ import mrtjp.core.vec.Point
 import mrtjp.projectred.fabrication.SEIntegratedCircuit._
 import net.minecraft.nbt.NBTTagCompound
 
-import scala.collection.mutable.{Map => MMap, Set => MSet}
+import scala.collection.mutable
+import scala.collection.mutable.{Map => MMap, Buffer => MBuffer, Set => MSet}
 
 trait IWireICTile
 {
@@ -130,10 +131,10 @@ abstract class WireICTile extends ICTile with TConnectableICTile with ISEWireTil
 
 private class WireNetChannel
 {
-    val points = MSet[(Point, Int)]()
+    val points = MBuffer[(Point, Int)]()
 
-    val inputs = MSet[(Point, Int)]()
-    val outputs = MSet[(Point, Int)]()
+    val inputs = MBuffer[(Point, Int)]()
+    val outputs = MBuffer[(Point, Int)]()
 
     private val inputsToRegIDMap = MMap[(Point, Int), Int]()
     private var outputRegID = -1
@@ -180,7 +181,7 @@ private class WireNetChannel
 
 class ImplicitWireNet(ic:ICTileMapContainer, p:Point, r:Int) extends IWireNet
 {
-    override val points = MSet[(Point, Int)]()
+    override val points = MBuffer[(Point, Int)]()
 
     private var regID = -1
 
@@ -221,12 +222,12 @@ class ImplicitWireNet(ic:ICTileMapContainer, p:Point, r:Int) extends IWireNet
 
 class WireNet(ic:ICTileMapContainer, p:Point, mask:Int) extends IWireNet
 {
-    override val points = MSet[(Point, Int)]()
+    override val points = MBuffer[(Point, Int)]()
 
-    private val channels = MSet[WireNetChannel]()
+    private val channels = MBuffer[WireNetChannel]()
 
-    private val inputs = MSet[(Point, Int)]()
-    private val outputs = MSet[(Point, Int)]()
+    private val inputs = MBuffer[(Point, Int)]()
+    private val outputs = MBuffer[(Point, Int)]()
 
     private val busWires = MSet[(Point, Int)]()
     private val portWires = MSet[(Point, Int)]()


### PR DESCRIPTION
Bus signals within ICs get scrambled on world load because although the registers are properly saved, they are not necessarily in the same order when the world is reloaded and the IC is recompiled. So for example, the register representing the white signal could be at index 0 the first time, and then index 15 the next time the IC is compiled.

Fixes #1484, fixes #1448, fixes #1342, fixes #1245