### PR TITLE
Fix Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ jdk:
   - oraclejdk8
   - openjdk8
 
+dist: trusty
+
 install: ./gradlew setupCIWorkspace -S
 script: ./gradlew build -S
 


### PR DESCRIPTION
Travis CI stopped working after they changed the default ubuntu os version to xenial, so I switched it back.