### PR TITLE
Update dependency on CBMultipart

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -3,7 +3,7 @@ forge_version=36.1.0
 mod_version=4.9.4
 
 ccl_version=4.0.0.+
-cbm_version=3.0.0.+
+cbm_version=3.0.1.+
 
 jei_version=7.6.1.+
 

--- a/src/expansion/scala/mrtjp/projectred/expansion/TileSolarPanel.scala
+++ b/src/expansion/scala/mrtjp/projectred/expansion/TileSolarPanel.scala
@@ -31,7 +31,7 @@ import net.minecraft.item.{Item, ItemStack, ItemUseContext}
 import net.minecraft.nbt.CompoundNBT
 import net.minecraft.resources.IResourceManager
 import net.minecraft.util.ResourceLocation
-import net.minecraft.util.math.shapes.VoxelShape
+import net.minecraft.util.math.shapes.{ISelectionContext, VoxelShape}
 import net.minecraft.world.World
 import net.minecraftforge.api.distmarker.{Dist, OnlyIn}
 import net.minecraftforge.client.model.geometry.IModelGeometry
@@ -67,8 +67,8 @@ class SolarPanelPart extends TMultiPart with TFaceElectricalDevice with ILowLoad
 
     override def getBounds:Cuboid6 = FaceMicroFactory.aBounds(0x10|side)
 
-    override def getOutlineShape:VoxelShape = FaceMicroFactory.aShapes(0x10|side)
-    override def getCollisionShape:VoxelShape = FaceMicroFactory.aShapes(0x10|side)
+    override def getShape(context:ISelectionContext):VoxelShape = FaceMicroFactory.aShapes(0x10|side)
+
     override def getOcclusionShape:VoxelShape = SolarPanelPart.oShapes(side)
 
     override def doesRotate = false

--- a/src/illumination/scala/mrtjp/projectred/illumination/buttonpart.scala
+++ b/src/illumination/scala/mrtjp/projectred/illumination/buttonpart.scala
@@ -16,7 +16,7 @@ import net.minecraft.client.renderer.IRenderTypeBuffer
 import net.minecraft.entity.player.PlayerEntity
 import net.minecraft.item.ItemStack
 import net.minecraft.nbt.CompoundNBT
-import net.minecraft.util.math.shapes.VoxelShape
+import net.minecraft.util.math.shapes.{ISelectionContext, VoxelShape}
 import net.minecraft.util.{ActionResultType, Hand}
 
 class LightButtonPart(partType:MultiPartType[_], colour:Int)
@@ -91,11 +91,11 @@ class LightButtonPart(partType:MultiPartType[_], colour:Int)
         }
     }
 
-    override def getCollisionShape:VoxelShape =
+    override def getCollisionShape(context:ISelectionContext):VoxelShape =
         if (tile == null) {
             VoxelShapeCache.getShape(Cuboid6.full)
         } else
-            super.getCollisionShape
+            super.getCollisionShape(context)
 
 
     //    @SideOnly(Side.CLIENT)

--- a/src/illumination/scala/mrtjp/projectred/illumination/lightpart.scala
+++ b/src/illumination/scala/mrtjp/projectred/illumination/lightpart.scala
@@ -29,7 +29,7 @@ import net.minecraft.entity.player.PlayerEntity
 import net.minecraft.item.{Item, ItemStack, ItemUseContext}
 import net.minecraft.nbt.CompoundNBT
 import net.minecraft.util.math.BlockPos
-import net.minecraft.util.math.shapes.VoxelShape
+import net.minecraft.util.math.shapes.{ISelectionContext, VoxelShape}
 import net.minecraft.util.{Direction, ResourceLocation}
 import net.minecraft.world.World
 import net.minecraftforge.api.distmarker.{Dist, OnlyIn}
@@ -168,8 +168,8 @@ class BaseLightPart(definition:LightPartDefinition, colour:Int, inverted:Boolean
 
     def getLightBounds:Cuboid6 = definition.getGlowBounds(getSide)
 
-    override def getOutlineShape:VoxelShape = definition.getShape(getSide)
-    override def getOcclusionShape:VoxelShape = getOutlineShape
+    override def getShape(context: ISelectionContext):VoxelShape = definition.getShape(getSide)
+    override def getOcclusionShape:VoxelShape = getShape(ISelectionContext.empty())
 
     override def getType:MultiPartType[_] = definition.multiPartType(colour, inverted)
 

--- a/src/integration/scala/mrtjp/projectred/integration/gatepart.scala
+++ b/src/integration/scala/mrtjp/projectred/integration/gatepart.scala
@@ -26,7 +26,7 @@ import net.minecraft.entity.player.PlayerEntity
 import net.minecraft.item.{ItemStack, ItemUseContext}
 import net.minecraft.nbt.CompoundNBT
 import net.minecraft.util.math.BlockPos
-import net.minecraft.util.math.shapes.VoxelShape
+import net.minecraft.util.math.shapes.{ISelectionContext, VoxelShape}
 import net.minecraft.util.{ActionResultType, Direction, Hand}
 import net.minecraft.world.chunk.Chunk
 import net.minecraftforge.api.distmarker.{Dist, OnlyIn}
@@ -163,9 +163,9 @@ abstract class GatePart(gateType:GateType) extends TMultiPart with TNormalOcclus
         if (!world.isClientSide) notifyAllExternals()
     }
 
-    override def onChunkLoad()
+    override def onChunkLoad(chunk: Chunk)
     {
-        super.onChunkLoad()
+        super.onChunkLoad(chunk)
         if (tile != null) {
             gateLogicOnWorldLoad()
         }
@@ -199,8 +199,8 @@ abstract class GatePart(gateType:GateType) extends TMultiPart with TNormalOcclus
     override def getType = gateType.getPartType
 
     override def getOcclusionShape:VoxelShape = GatePart.oShapes(side)
-    override def getCollisionShape:VoxelShape = FaceMicroFactory.aShapes(0x10|side)
-    override def getOutlineShape:VoxelShape = FaceMicroFactory.aShapes(0x10|side)
+    override def getCollisionShape(context:ISelectionContext):VoxelShape = FaceMicroFactory.aShapes(0x10|side)
+    override def getShape(context: ISelectionContext):VoxelShape = getCollisionShape(context)
 
     override def getStrength(player:PlayerEntity, hit:PartRayTraceResult) = 2/30f
 
@@ -280,7 +280,7 @@ abstract class GatePart(gateType:GateType) extends TMultiPart with TNormalOcclus
         RenderGate.renderCustomDynamic(this, Vector3.ZERO, mStack, buffers, packedLight, packedOverlay, partialTicks)
     }
 
-    override def getBounds:Cuboid6 = new Cuboid6(getOutlineShape.bounds())
+    override def getBounds:Cuboid6 = new Cuboid6(getShape(ISelectionContext.empty()).bounds())
 
     override def getBreakingIcon(hit:PartRayTraceResult):TextureAtlasSprite = ComponentStore.baseIcon
 

--- a/src/integration/scala/mrtjp/projectred/integration/gatepartarray.scala
+++ b/src/integration/scala/mrtjp/projectred/integration/gatepartarray.scala
@@ -17,7 +17,7 @@ import net.minecraft.entity.player.PlayerEntity
 import net.minecraft.nbt.CompoundNBT
 import net.minecraft.util.Direction
 import net.minecraft.util.math.BlockPos
-import net.minecraft.util.math.shapes.VoxelShape
+import net.minecraft.util.math.shapes.{ISelectionContext, VoxelShape}
 
 abstract class ArrayGatePart(gateType:GateType) extends RedstoneGatePart(gateType) with IRedwirePart with TFaceRSPropagation
 {
@@ -300,8 +300,8 @@ abstract class ArrayGatePartCrossing(gateType:GateType) extends ArrayGatePart(ga
         }
     }
 
-    override def getOutlineShape:VoxelShape =  ArrayGatePart.cShapes(side)
-    override def getCollisionShape:VoxelShape = ArrayGatePart.cShapes(side)
+    override def getShape(context:ISelectionContext):VoxelShape = getCollisionShape(context)
+    override def getCollisionShape(context:ISelectionContext):VoxelShape = ArrayGatePart.cShapes(side)
     override def getOcclusionShape:VoxelShape = ArrayGatePart.oShapes(side)
 
     override def onSignalUpdate():Unit = {
@@ -390,8 +390,8 @@ class ANDCell extends ArrayGatePartTopOnly(GateType.AND_CELL) with TSimpleRSGate
 
     override def calcOutput(input:Int):Int = if (input == 4 && signal != 0) 1 else 0
 
-    override def getOutlineShape:VoxelShape =  ArrayGatePart.cShapes(side)
-    override def getCollisionShape:VoxelShape = ArrayGatePart.cShapes(side)
+    override def getShape(context:ISelectionContext):VoxelShape = getCollisionShape(context)
+    override def getCollisionShape(context:ISelectionContext):VoxelShape = ArrayGatePart.cShapes(side)
     override def getOcclusionShape:VoxelShape = ArrayGatePart.oShapes(side)
 }
 

--- a/src/integration/scala/mrtjp/projectred/integration/gatepartbundled.scala
+++ b/src/integration/scala/mrtjp/projectred/integration/gatepartbundled.scala
@@ -21,7 +21,7 @@ import net.minecraft.entity.player.PlayerEntity
 import net.minecraft.item.ItemStack
 import net.minecraft.nbt.CompoundNBT
 import net.minecraft.util.Direction
-import net.minecraft.util.math.shapes.VoxelShape
+import net.minecraft.util.math.shapes.{ISelectionContext, VoxelShape}
 
 import java.util.Random
 import scala.jdk.CollectionConverters._
@@ -553,7 +553,7 @@ class BusInputPanel extends BundledGatePart(GateType.BUS_INPUT_PANEL)
         gateLogicOnChange()
     }
 
-    override def getOutlineShape:VoxelShape =
+    override def getShape(context:ISelectionContext):VoxelShape =
         BusInputPanel.getOrCreateOutline(orientation&0xFF, pressMask&0xFFFF)
 
 

--- a/src/transmission/scala/mrtjp/projectred/transmission/wireabstracts.scala
+++ b/src/transmission/scala/mrtjp/projectred/transmission/wireabstracts.scala
@@ -243,8 +243,6 @@ abstract class WirePart(wireType:WireType) extends TMultiPart with TWireCommons 
 
     override def getStrength(player:PlayerEntity, hit:PartRayTraceResult) = 2/30f
 
-    override def getInteractionShape: VoxelShape = getShape(ISelectionContext.empty())
-
     override def getShape(context: ISelectionContext) = new IndexedVoxelShape(WireBoxes.sShapes(getThickness)(side), 0)
 
     override def getCollisionShape(context:ISelectionContext) = VoxelShapes.empty()

--- a/src/transmission/scala/mrtjp/projectred/transmission/wireabstracts.scala
+++ b/src/transmission/scala/mrtjp/projectred/transmission/wireabstracts.scala
@@ -24,7 +24,7 @@ import net.minecraft.inventory.EquipmentSlotType
 import net.minecraft.item.{ItemStack, ItemUseContext}
 import net.minecraft.nbt.CompoundNBT
 import net.minecraft.util.math.BlockPos
-import net.minecraft.util.math.shapes.{VoxelShape, VoxelShapes}
+import net.minecraft.util.math.shapes.{ISelectionContext, VoxelShape, VoxelShapes}
 import net.minecraft.util.{ActionResultType, Direction, Hand, SoundCategory}
 import net.minecraftforge.api.distmarker.{Dist, OnlyIn}
 
@@ -243,9 +243,11 @@ abstract class WirePart(wireType:WireType) extends TMultiPart with TWireCommons 
 
     override def getStrength(player:PlayerEntity, hit:PartRayTraceResult) = 2/30f
 
-    override def getOutlineShape = new IndexedVoxelShape(WireBoxes.sShapes(getThickness)(side), 0)
+    override def getInteractionShape: VoxelShape = getShape(ISelectionContext.empty())
 
-    override def getCollisionShape = VoxelShapes.empty()
+    override def getShape(context: ISelectionContext) = new IndexedVoxelShape(WireBoxes.sShapes(getThickness)(side), 0)
+
+    override def getCollisionShape(context:ISelectionContext) = VoxelShapes.empty()
 
     override def getOcclusionShape = WireBoxes.oShapes(getThickness)(side)
 
@@ -366,7 +368,7 @@ abstract class FramedWirePart(wireType:WireType) extends TMultiPart with TWireCo
         else super.getDrops
     }
 
-    override def getOutlineShape = new IndexedVoxelShape(getCollisionShape, 0)
+    override def getShape(context: ISelectionContext) = new IndexedVoxelShape(getCollisionShape(context), 0)
 
     override def getOcclusionShape =
     {
@@ -375,7 +377,7 @@ abstract class FramedWirePart(wireType:WireType) extends TMultiPart with TWireCo
         else fOShapes(6)
     }
 
-    override def getCollisionShape =
+    override def getCollisionShape(context: ISelectionContext) =
     {
         import mrtjp.projectred.transmission.WireBoxes._
         var m = 0


### PR DESCRIPTION
I'm canary testing some stuff with CBMultipart and ProjectRed on 1.16.5, and after the latest CBMultipart build, none of the parts from PR have selection boxes. This PR appears to fix all of that; I followed the same refactor pattern as the [commit that introduced the change](https://github.com/TheCBProject/CBMultipart/commit/1b953b5a234a3f7129420bfd33e9accb7bf0249f#diff-aa89a7287cf261e185cc9fb6ce15dd006aeeac86dd88a6969a45f40733108c03L161). Wasn't sure if this was in the works officially, so I figured there's no harm in submitting a PR for it.