### PR TITLE
fix: comparators rendering as repeaters

### DIFF
--- a/src/integration/scala/mrtjp/projectred/integration/gatepartseq.scala
+++ b/src/integration/scala/mrtjp/projectred/integration/gatepartseq.scala
@@ -666,7 +666,7 @@ class Synchronizer extends RedstoneGatePart(GateType.SYNCHRONIZER) with TExtraSt
     def pulsing:Boolean = (state2&4) != 0
 }
 
-class Comparator extends RedstoneGatePart(GateType.REPEATER) with INeighborTileChangePart
+class Comparator extends RedstoneGatePart(GateType.COMPARATOR) with INeighborTileChangePart
 {
     var lState2:Short = 0
 


### PR DESCRIPTION
Accidentally used the repeater gate type in the comparator gate. This needs to be picked into 1.15.