### PR TITLE
Implement ore and cave worldgen

### DIFF
--- a/src/core/scala/mrtjp/projectred/core/Configurator.scala
+++ b/src/core/scala/mrtjp/projectred/core/Configurator.scala
@@ -33,7 +33,7 @@ object Configurator extends ModConfig("projectred-core") {
     var pipeRoutingFX = true
 
     /** World Gen * */
-    //    var gen_MarbleCave = true
+    var gen_MarbleCave = true
     //    var gen_MarbleCave_resistance = 0
     //    var gen_MarbleCave_retro = false
     //    var gen_Volcano = true
@@ -109,7 +109,7 @@ object Configurator extends ModConfig("projectred-core") {
         //        gen_Peridot_resistance = gen.put("Peridot Ore resistance", gen_Peridot_resistance)
         //        gen_Peridot_retro = gen.put("Peridot Ore retrogen", gen_Peridot_retro)
         //
-        //        gen_MarbleCave = gen.put("Marble Caves", gen_MarbleCave)
+        gen_MarbleCave = gen.put("Marble Caves", gen_MarbleCave)
         //        gen_MarbleCave_resistance = gen.put("Marble Caves resistance", gen_MarbleCave_resistance)
         //        gen_MarbleCave_retro = gen.put("Marble Caves retrogen", gen_MarbleCave_retro)
         //

--- a/src/core/scala/mrtjp/projectred/core/Configurator.scala
+++ b/src/core/scala/mrtjp/projectred/core/Configurator.scala
@@ -39,25 +39,25 @@ object Configurator extends ModConfig("projectred-core") {
     //    var gen_Volcano = true
     //    var gen_Volcano_resistance = 0
     //    var gen_Volcano_retro = false
-    //    var gen_Ruby = true
+    var gen_Ruby = true
     //    var gen_Ruby_resistance = 0
     //    var gen_Ruby_retro = false
-    //    var gen_Sapphire = true
+    var gen_Sapphire = true
     //    var gen_Sapphire_resistance = 0
     //    var gen_Sapphire_retro = false
-    //    var gen_Peridot = true
+    var gen_Peridot = true
     //    var gen_Peridot_resistance = 0
     //    var gen_Peridot_retro = false
-    //    var gen_Copper = true
+    var gen_Copper = true
     //    var gen_Copper_resistance = 0
     //    var gen_Copper_retro = false
-    //    var gen_Tin = true
+    var gen_Tin = true
     //    var gen_Tin_resistance = 0
     //    var gen_Tin_retro = false
-    //    var gen_Silver = true
+    var gen_Silver = true
     //    var gen_Silver_resistance = 0
     //    var gen_Silver_retro = false
-    //    var gen_Electrotine = true
+    var gen_Electrotine = true
     //    var gen_Electrotine_resistance = 0
     //    var gen_Electrotine_retro = false
 
@@ -96,16 +96,16 @@ object Configurator extends ModConfig("projectred-core") {
         lightHaloMax = rendering.put("Light Halo Render Count", lightHaloMax, "Number of lights to render, -1 for unlimited")
         pipeRoutingFX = rendering.put("Routed Pipe FX", pipeRoutingFX, "If set to false, routed pipes will not render routing fx such as bubbles and lasers.")
 
-        //        val gen = new BaseCategory("World Gen", "Contains settings related to world gen. You can enable/disable each ore or strucure, change retro generation settings, and increase how rare something is by increasing the resistance value.")
-        //        gen_Ruby = gen.put("Ruby Ore", gen_Ruby)
+        val gen = new BaseCategory("World Gen", "Contains settings related to world gen. You can enable/disable each ore or strucure, change retro generation settings, and increase how rare something is by increasing the resistance value.")
+        gen_Ruby = gen.put("Ruby Ore", gen_Ruby)
         //        gen_Ruby_resistance = gen.put("Ruby Ore resistance", gen_Ruby_resistance)
         //        gen_Ruby_retro = gen.put("Ruby Ore retrogen", gen_Ruby_retro)
         //
-        //        gen_Sapphire = gen.put("Sapphire Ore", gen_Sapphire)
+        gen_Sapphire = gen.put("Sapphire Ore", gen_Sapphire)
         //        gen_Sapphire_resistance = gen.put("Sapphire Ore resistance", gen_Sapphire_resistance)
         //        gen_Sapphire_retro = gen.put("Sapphire Ore retrogen", gen_Sapphire_retro)
         //
-        //        gen_Peridot = gen.put("Peridot Ore", gen_Peridot)
+        gen_Peridot = gen.put("Peridot Ore", gen_Peridot)
         //        gen_Peridot_resistance = gen.put("Peridot Ore resistance", gen_Peridot_resistance)
         //        gen_Peridot_retro = gen.put("Peridot Ore retrogen", gen_Peridot_retro)
         //
@@ -117,19 +117,19 @@ object Configurator extends ModConfig("projectred-core") {
         //        gen_Volcano_resistance = gen.put("Volcano resistance", gen_Volcano_resistance)
         //        gen_Volcano_retro = gen.put("Volcano retrogen", gen_Volcano_retro)
         //
-        //        gen_Copper = gen.put("Copper Ore", gen_Copper)
+        gen_Copper = gen.put("Copper Ore", gen_Copper)
         //        gen_Copper_resistance = gen.put("Copper Ore resistance", gen_Copper_resistance)
         //        gen_Copper_retro = gen.put("Copper Ore retrogen", gen_Copper_retro)
         //
-        //        gen_Tin = gen.put("Tin Ore", gen_Tin)
+        gen_Tin = gen.put("Tin Ore", gen_Tin)
         //        gen_Tin_resistance = gen.put("Tin Ore resistance", gen_Tin_resistance)
         //        gen_Tin_retro = gen.put("Tin Ore retrogen", gen_Tin_retro)
         //
-        //        gen_Silver = gen.put("Silver Ore", gen_Silver)
+        gen_Silver = gen.put("Silver Ore", gen_Silver)
         //        gen_Silver_resistance = gen.put("Silver Ore resistance", gen_Silver_resistance)
         //        gen_Silver_retro = gen.put("Silver Ore retrogen", gen_Silver_retro)
         //
-        //        gen_Electrotine = gen.put("Electrotine Ore", gen_Electrotine)
+        gen_Electrotine = gen.put("Electrotine Ore", gen_Electrotine)
         //        gen_Electrotine_resistance = gen.put("Electrotine Ore resistance", gen_Electrotine_resistance)
         //        gen_Electrotine_retro = gen.put("Electrotine Ore retrogen", gen_Electrotine_retro)
 

--- a/src/exploration/scala/mrtjp/projectred/ProjectRedExploration.scala
+++ b/src/exploration/scala/mrtjp/projectred/ProjectRedExploration.scala
@@ -1,9 +1,12 @@
 package mrtjp.projectred
 
 import mrtjp.projectred.exploration._
+import mrtjp.projectred.exploration.init.ExplorationFeatures
 import net.minecraftforge.eventbus.api.SubscribeEvent
 import net.minecraftforge.fml.event.lifecycle.{FMLClientSetupEvent, FMLCommonSetupEvent, FMLDedicatedServerSetupEvent, FMLLoadCompleteEvent}
 import net.minecraftforge.scorge.lang.ScorgeModLoadingContext
+
+import scala.jdk.FunctionWrappers.AsJavaSupplier
 
 object ProjectRedExploration {
     final var MOD_ID = "projectred-exploration"
@@ -17,6 +20,7 @@ class ProjectRedExploration {
     @SubscribeEvent
     def onCommonSetup(event: FMLCommonSetupEvent) {
         ExplorationProxy.commonSetup(event)
+        event.enqueueWork(AsJavaSupplier(() => ExplorationFeatures.load()))
     }
 
     @SubscribeEvent

--- a/src/exploration/scala/mrtjp/projectred/ProjectRedExploration.scala
+++ b/src/exploration/scala/mrtjp/projectred/ProjectRedExploration.scala
@@ -14,8 +14,13 @@ object ProjectRedExploration {
 
 class ProjectRedExploration {
 
-    ScorgeModLoadingContext.get.getModEventBus.register(this)
-    ExplorationContent.register(ScorgeModLoadingContext.get.getModEventBus)
+    {
+        val modEventBus = ScorgeModLoadingContext.get.getModEventBus
+        modEventBus.register(this)
+
+        ExplorationContent.register(modEventBus)
+        ExplorationFeatures.register(modEventBus)
+    }
 
     @SubscribeEvent
     def onCommonSetup(event: FMLCommonSetupEvent) {

--- a/src/exploration/scala/mrtjp/projectred/exploration/init/ExplorationFeatures.scala
+++ b/src/exploration/scala/mrtjp/projectred/exploration/init/ExplorationFeatures.scala
@@ -1,0 +1,69 @@
+package mrtjp.projectred.exploration.init
+
+import mrtjp.projectred.ProjectRedExploration.MOD_ID
+import mrtjp.projectred.core.Configurator
+import mrtjp.projectred.exploration.ExplorationContent._
+import net.minecraft.block.Block
+import net.minecraft.util.ResourceLocation
+import net.minecraft.util.registry.{Registry, WorldGenRegistries}
+import net.minecraft.world.gen.GenerationStage
+import net.minecraft.world.gen.feature.{ConfiguredFeature, Feature, OreFeatureConfig}
+import net.minecraft.world.gen.placement.{Placement, TopSolidRangeConfig}
+import net.minecraftforge.common.MinecraftForge
+import net.minecraftforge.event.world.BiomeLoadingEvent
+import net.minecraftforge.eventbus.api.EventPriority
+
+import java.util.function.Supplier
+
+object ExplorationFeatures
+{
+    var oreRuby:ConfiguredFeature[_, _] = _
+    var oreSapphire:ConfiguredFeature[_, _] = _
+    var orePeridot:ConfiguredFeature[_, _] = _
+    var oreCopper:ConfiguredFeature[_, _] = _
+    var oreTin:ConfiguredFeature[_, _] = _
+    var oreSilver:ConfiguredFeature[_, _] = _
+    var oreElectrotine:ConfiguredFeature[_, _] = _
+
+    def load():Unit = {
+        oreRuby = registerStandardOre("ruby_ore", blockRubyOre, 8, 12, 20, 1)
+        oreSapphire = registerStandardOre("sapphire_ore", blockSapphireOre, 8, 12, 20, 1)
+        orePeridot = registerStandardOre("peridot_dore", blockPeridotOre, 10, 18, 26, 1)
+
+        oreCopper = registerStandardOre("ore_copper", blockCopperOre, 8, 0, 64, 16)
+        oreTin = registerStandardOre("ore_tin", blockTinOre, 8, 0, 48, 10)
+        oreSilver = registerStandardOre("ore_silver", blockSilverOre, 9, 0, 32, 8)
+
+        oreElectrotine = registerStandardOre("ore_electrotine", blockElectrotineOre, 8, 0, 16, 4)
+
+        MinecraftForge.EVENT_BUS.addListener(EventPriority.HIGH, onBiomeLoadingEvent)
+    }
+
+    def onBiomeLoadingEvent(event:BiomeLoadingEvent):Unit = {
+        val c = event.getCategory
+        import net.minecraft.world.biome.Biome.Category._
+
+        def addOre(cf:ConfiguredFeature[_, _]):Unit = {
+            event.getGeneration.addFeature(GenerationStage.Decoration.UNDERGROUND_ORES, cf)
+        }
+
+        if (c != NONE && c != THEEND && c != NETHER) { // If overworld
+            import Configurator._
+            if (gen_Ruby)        addOre(oreRuby)
+            if (gen_Sapphire)    addOre(oreSapphire)
+            if (gen_Peridot)     addOre(orePeridot)
+            if (gen_Copper)      addOre(oreCopper)
+            if (gen_Tin)         addOre(oreTin)
+            if (gen_Silver)      addOre(oreSilver)
+            if (gen_Electrotine) addOre(oreElectrotine)
+        }
+    }
+
+    private def registerStandardOre(key:String, block:Supplier[Block], veinSize:Int, minY:Int, maxY:Int, count:Int):ConfiguredFeature[_, _] = {
+        val cf = Feature.ORE.configured(new OreFeatureConfig(OreFeatureConfig.FillerBlockType.NATURAL_STONE, block.get().defaultBlockState(), veinSize))
+                .squared()
+                .count(count)
+        val cf2:ConfiguredFeature[_, _] = cf.decorated(Placement.RANGE.configured(new TopSolidRangeConfig(minY, minY, maxY))) //Scalac bug requires this on separate line
+        Registry.register(WorldGenRegistries.CONFIGURED_FEATURE, new ResourceLocation(MOD_ID, key), cf2)
+    }
+}

--- a/src/exploration/scala/mrtjp/projectred/exploration/init/ExplorationFeatures.scala
+++ b/src/exploration/scala/mrtjp/projectred/exploration/init/ExplorationFeatures.scala
@@ -3,20 +3,29 @@ package mrtjp.projectred.exploration.init
 import mrtjp.projectred.ProjectRedExploration.MOD_ID
 import mrtjp.projectred.core.Configurator
 import mrtjp.projectred.exploration.ExplorationContent._
+import mrtjp.projectred.exploration.world.gen.MarbleCaveWorldCarver
 import net.minecraft.block.Block
 import net.minecraft.util.ResourceLocation
 import net.minecraft.util.registry.{Registry, WorldGenRegistries}
 import net.minecraft.world.gen.GenerationStage
-import net.minecraft.world.gen.feature.{ConfiguredFeature, Feature, OreFeatureConfig}
+import net.minecraft.world.gen.carver.{ConfiguredCarver, WorldCarver}
+import net.minecraft.world.gen.feature.{ConfiguredFeature, Feature, OreFeatureConfig, ProbabilityConfig}
 import net.minecraft.world.gen.placement.{Placement, TopSolidRangeConfig}
 import net.minecraftforge.common.MinecraftForge
 import net.minecraftforge.event.world.BiomeLoadingEvent
-import net.minecraftforge.eventbus.api.EventPriority
+import net.minecraftforge.eventbus.api.{EventPriority, IEventBus}
+import net.minecraftforge.registries.{DeferredRegister, ForgeRegistries}
 
 import java.util.function.Supplier
 
 object ExplorationFeatures
 {
+    val WORLD_CARVERS = DeferredRegister.create[WorldCarver[_]](ForgeRegistries.WORLD_CARVERS, MOD_ID)
+
+    // World Carvers
+    var marbleCaveCarver = WORLD_CARVERS.register("marble_cave", () => new MarbleCaveWorldCarver(ProbabilityConfig.CODEC, 256))
+
+    // Configured ores
     var oreRuby:ConfiguredFeature[_, _] = _
     var oreSapphire:ConfiguredFeature[_, _] = _
     var orePeridot:ConfiguredFeature[_, _] = _
@@ -24,6 +33,13 @@ object ExplorationFeatures
     var oreTin:ConfiguredFeature[_, _] = _
     var oreSilver:ConfiguredFeature[_, _] = _
     var oreElectrotine:ConfiguredFeature[_, _] = _
+
+    // Configured carvers
+    var marbleCave:ConfiguredCarver[_] = _
+
+    def register(bus:IEventBus):Unit = {
+        WORLD_CARVERS.register(bus)
+    }
 
     def load():Unit = {
         oreRuby = registerStandardOre("ruby_ore", blockRubyOre, 8, 12, 20, 1)
@@ -36,6 +52,8 @@ object ExplorationFeatures
 
         oreElectrotine = registerStandardOre("ore_electrotine", blockElectrotineOre, 8, 0, 16, 4)
 
+        marbleCave = registerMarbleCaveCarver("marble_cave", 0.02F)
+
         MinecraftForge.EVENT_BUS.addListener(EventPriority.HIGH, onBiomeLoadingEvent)
     }
 
@@ -43,9 +61,10 @@ object ExplorationFeatures
         val c = event.getCategory
         import net.minecraft.world.biome.Biome.Category._
 
-        def addOre(cf:ConfiguredFeature[_, _]):Unit = {
+        def addOre(cf:ConfiguredFeature[_, _]):Unit =
             event.getGeneration.addFeature(GenerationStage.Decoration.UNDERGROUND_ORES, cf)
-        }
+        def addCarver(cc:ConfiguredCarver[_]):Unit =
+            event.getGeneration.addCarver(GenerationStage.Carving.AIR, cc)
 
         if (c != NONE && c != THEEND && c != NETHER) { // If overworld
             import Configurator._
@@ -56,6 +75,7 @@ object ExplorationFeatures
             if (gen_Tin)         addOre(oreTin)
             if (gen_Silver)      addOre(oreSilver)
             if (gen_Electrotine) addOre(oreElectrotine)
+            if (gen_MarbleCave)  addCarver(marbleCave)
         }
     }
 
@@ -65,5 +85,10 @@ object ExplorationFeatures
                 .count(count)
         val cf2:ConfiguredFeature[_, _] = cf.decorated(Placement.RANGE.configured(new TopSolidRangeConfig(minY, minY, maxY))) //Scalac bug requires this on separate line
         Registry.register(WorldGenRegistries.CONFIGURED_FEATURE, new ResourceLocation(MOD_ID, key), cf2)
+    }
+
+    private def registerMarbleCaveCarver(key:String, probability:Float):ConfiguredCarver[_] = {
+        val cc = marbleCaveCarver.get().configured(new ProbabilityConfig(probability))
+        Registry.register(WorldGenRegistries.CONFIGURED_CARVER, new ResourceLocation(MOD_ID, key), cc)
     }
 }

--- a/src/exploration/scala/mrtjp/projectred/exploration/world/gen/MarbleCaveWorldCarver.scala
+++ b/src/exploration/scala/mrtjp/projectred/exploration/world/gen/MarbleCaveWorldCarver.scala
@@ -1,0 +1,48 @@
+package mrtjp.projectred.exploration.world.gen
+
+import com.mojang.serialization.Codec
+import mrtjp.projectred.exploration.ExplorationContent
+import net.minecraft.block.{Block, Blocks}
+import net.minecraft.util.Direction
+import net.minecraft.util.math.BlockPos
+import net.minecraft.world.biome.Biome
+import net.minecraft.world.chunk.IChunk
+import net.minecraft.world.gen.carver.CaveWorldCarver
+import net.minecraft.world.gen.feature.ProbabilityConfig
+import org.apache.commons.lang3.mutable.MutableBoolean
+
+import java.util
+import java.util.{Random, function}
+import scala.jdk.CollectionConverters._
+
+class MarbleCaveWorldCarver(codec:Codec[ProbabilityConfig], genHeight:Int) extends CaveWorldCarver(codec, genHeight)
+{
+    protected val MARBLE = ExplorationContent.blockMarble.get().defaultBlockState()
+
+    {
+        val blockSet = Set.newBuilder[Block]
+        blockSet ++= replaceableBlocks.asScala
+        blockSet += ExplorationContent.blockMarble.get()
+        replaceableBlocks = blockSet.result().asJava
+    }
+
+    override protected def carveBlock(p_230358_1_ :IChunk, p_230358_2_ :function.Function[BlockPos, Biome], p_230358_3_ :util.BitSet, p_230358_4_ :Random, p_230358_5_ :BlockPos.Mutable, p_230358_6_ :BlockPos.Mutable, p_230358_7_ :BlockPos.Mutable, p_230358_8_ :Int, p_230358_9_ :Int, p_230358_10_ :Int, p_230358_11_ :Int, p_230358_12_ :Int, p_230358_13_ :Int, p_230358_14_ :Int, p_230358_15_ :Int, p_230358_16_ :MutableBoolean):Boolean = {
+        val result = super.carveBlock(p_230358_1_, p_230358_2_, p_230358_3_, p_230358_4_, p_230358_5_, p_230358_6_, p_230358_7_, p_230358_8_, p_230358_9_, p_230358_10_, p_230358_11_, p_230358_12_, p_230358_13_, p_230358_14_, p_230358_15_, p_230358_16_)
+
+        if (result) { //this position was carved. Surround it with marble
+            val pos = new BlockPos(p_230358_11_, p_230358_14_, p_230358_12_).mutable()
+            val carvedState = p_230358_1_.getBlockState(pos)
+
+            if (carvedState.is(Blocks.AIR) || carvedState.is(Blocks.CAVE_AIR)) {
+                for (s <- 0 until 6) {
+                    pos.set(p_230358_11_, p_230358_14_, p_230358_12_).move(Direction.values()(s))
+                    val adjacentState = p_230358_1_.getBlockState(pos)
+                    if (canReplaceBlock(adjacentState)) {
+                        p_230358_1_.setBlockState(pos, MARBLE, false)
+                    }
+                }
+            }
+        }
+        result
+    }
+}


### PR DESCRIPTION
* All ores now generate properly and can be toggled in the config file
* Marble caves generate using existing vanilla cave generation logic, which results in higher quality caves with no performance cost.
* Volcano generation will come later. Hopefully the vanilla mountain generator is also just as re-usable.
* Vanilla worldgen is really easy to extend now, which is cool. But Forge still needs to add registries for the Configured generation stuff. For now, you have to add them to vanilla registries, which is shady.
* Closes #1648