### PR TITLE
Add computercraft compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,6 +97,7 @@ minecraft {
 repositories {
     mavenLocal()
     maven { url = "https://proxy-maven.covers1624.net/" }
+    maven { url = "https://squiddev.cc/maven/" }
 }
 
 configurations {
@@ -130,6 +131,8 @@ dependencies {
     coreCompileOnly fg.deobf("mezz.jei:jei-${config.mc_version}:${config.jei_version}:api")
     // at runtime, use the full JEI jar
     coreRuntimeOnly fg.deobf("mezz.jei:jei-${config.mc_version}:${config.jei_version}")
+
+    coreCompile fg.deobf("org.squiddev:cc-tweaked-${config.mc_version}:${config.cct_version}")
 }
 
 
@@ -189,7 +192,8 @@ sourceSets.findAll {it.name != "main" && it.name != "test" } each { set ->
                 spec.expand 'version': config.mod_version,
                         'mc_version': config.mc_version,
                         'ccl_version': resolve("CodeChickenLib"),
-                        'cbm_version': resolve("CBMultipart")
+                        'cbm_version': resolve("CBMultipart"),
+                        'cct_version': config.cct_version
             }
         }
     }

--- a/build.properties
+++ b/build.properties
@@ -6,7 +6,7 @@ ccl_version=4.0.2.+
 cbm_version=3.0.2.+
 
 jei_version=7.6.1.+
-
+cct_version=1.98.2
 
 scala_version=2.13.4
 scala_compat_version=2.13:0.9.1

--- a/src/core/resources/META-INF/mods.toml
+++ b/src/core/resources/META-INF/mods.toml
@@ -45,3 +45,9 @@ Redstone. The way it was meant to be.
     versionRange="[${cbm_version},)"
     ordering="AFTER"
     side="BOTH"
+[[dependencies.projectred-core]]
+    modId="computercraft"
+    mandatory=false
+    versionRange="[${cct_version},)"
+    ordering="AFTER"
+    side="BOTH"

--- a/src/core/scala/mrtjp/projectred/ProjectRedCore.scala
+++ b/src/core/scala/mrtjp/projectred/ProjectRedCore.scala
@@ -1,7 +1,9 @@
 package mrtjp.projectred
 
+import mrtjp.projectred.compatibility.ComputerCraftCompatibility
 import mrtjp.projectred.core._
 import net.minecraftforge.eventbus.api.SubscribeEvent
+import net.minecraftforge.fml.OptionalMod
 import net.minecraftforge.fml.event.lifecycle.{FMLClientSetupEvent, FMLCommonSetupEvent, FMLDedicatedServerSetupEvent, FMLLoadCompleteEvent}
 import net.minecraftforge.scorge.lang.ScorgeModLoadingContext
 
@@ -18,6 +20,9 @@ class ProjectRedCore {
     @SubscribeEvent
     def onCommonSetup(event: FMLCommonSetupEvent) {
         CoreProxy.commonSetup(event)
+
+        // Compatibility modules
+        OptionalMod.of[Any]("computercraft").ifPresent(_ => ComputerCraftCompatibility.init())
     }
 
     @SubscribeEvent

--- a/src/core/scala/mrtjp/projectred/compatibility/ComputerCraftCompatibility.scala
+++ b/src/core/scala/mrtjp/projectred/compatibility/ComputerCraftCompatibility.scala
@@ -1,0 +1,50 @@
+package mrtjp.projectred.compatibility
+
+import dan200.computercraft.api.ComputerCraftAPI
+import dan200.computercraft.api.redstone.IBundledRedstoneProvider
+import mrtjp.projectred.api.{IBundledTileInteraction, ProjectRedAPI}
+import mrtjp.projectred.core.BundledCommons
+import net.minecraft.util.Direction
+import net.minecraft.util.math.BlockPos
+import net.minecraft.world.World
+
+/**
+ * Provides bundled cable compatibility with ComputerCraft
+ */
+object ComputerCraftCompatibility
+{
+    def init():Unit = {
+        if (ProjectRedAPI.transmissionAPI != null) { // Check if Transmission is installed
+            println("Loading ProjectRed compatibility: ComputerCraft")
+            ComputerCraftAPI.registerBundledRedstoneProvider(new CCPRBundledRedstoneProvider)
+            ProjectRedAPI.transmissionAPI.registerBundledTileInteraction(new PRCCBundledTileInteraction)
+        }
+    }
+
+    /**
+     * This is used by ComputerCraft to query bundled signals from third-party entities
+     */
+    class CCPRBundledRedstoneProvider extends IBundledRedstoneProvider
+    {
+        override def getBundledRedstoneOutput(world:World, pos:BlockPos, side:Direction):Int = {
+            val sig = ProjectRedAPI.transmissionAPI.getBundledInput(world, pos.relative(side), side.getOpposite)
+            BundledCommons.packDigital(sig)
+        }
+    }
+
+    /**
+     * On the other side, this is used by ProjectRed to query bundled signals from third-party entities
+     */
+    class PRCCBundledTileInteraction extends IBundledTileInteraction
+    {
+        override def isValidInteractionFor(world:World, pos:BlockPos, side:Direction):Boolean =
+            ComputerCraftAPI.getBundledRedstoneOutput(world, pos, side) > -1
+
+        override def canConnectBundled(world:World, pos:BlockPos, side:Direction):Boolean = true
+
+        override def getBundledSignal(world:World, pos:BlockPos, side:Direction):Array[Byte] = {
+            val sig = ComputerCraftAPI.getBundledRedstoneOutput(world, pos, side)
+            BundledCommons.unpackDigital(null, sig)
+        }
+    }
+}


### PR DESCRIPTION
Allows ComputerCraft (CC Tweaked) to read/write to/from ProjectRed bundled cables.

Closes #1630