### PR TITLE
Bug fixes for stuff broken by Java port

### DIFF
--- a/integration/src/main/java/mrtjp/projectred/integration/client/GateModelRenderer.java
+++ b/integration/src/main/java/mrtjp/projectred/integration/client/GateModelRenderer.java
@@ -33,7 +33,7 @@ public class GateModelRenderer {
         return INSTANCES.get();
     }
 
-    private static final GateRenderer[] renderers = new GateRenderer[] {
+    private final GateRenderer[] renderers = new GateRenderer[] {
             new RenderOR(),
             new RenderNOR(),
             new RenderNOT(),

--- a/integration/src/main/java/mrtjp/projectred/integration/client/GateModelRenderer.java
+++ b/integration/src/main/java/mrtjp/projectred/integration/client/GateModelRenderer.java
@@ -1168,7 +1168,7 @@ public class GateModelRenderer {
 
         @Override
         public void renderDynamic(CCRenderState ccrs, Transformation t) {
-            pointer.renderModel(t, 0, ccrs);
+            pointer.renderModel(t, reflect ? 1 : 0, ccrs);
         }
     }
 
@@ -1231,13 +1231,14 @@ public class GateModelRenderer {
 
         @Override
         protected void prepareDynamic(IGateRenderData gate, float partialFrame) {
+            reflect = gate.shape() == 1;
             double interpPointer = !gate.isPointerStarted() ? 0f : (gate.pointerValue() + partialFrame) / gate.pointerMax();
             pointer.angle = interpPointer - MathHelper.pi / 2;
         }
 
         @Override
         public void renderDynamic(CCRenderState ccrs, Transformation t) {
-            pointer.renderModel(t, 0, ccrs);
+            pointer.renderModel(t, reflect ? 1 : 0, ccrs);
         }
     }
 

--- a/integration/src/main/java/mrtjp/projectred/integration/part/ComplexGatePart.java
+++ b/integration/src/main/java/mrtjp/projectred/integration/part/ComplexGatePart.java
@@ -316,6 +316,11 @@ public abstract class ComplexGatePart extends RedstoneGatePart {
             pointer_max = packet.readInt();
             pointer_start = packet.readLong();
         }
+
+        @Override
+        protected void gateLogicOnWorldLoad() {
+            if (pointer_start >= 0) pointer_start = level().getGameTime() - pointer_start;
+        }
         //endregion
 
         //region Packets

--- a/integration/src/main/java/mrtjp/projectred/integration/part/SimpleGatePart.java
+++ b/integration/src/main/java/mrtjp/projectred/integration/part/SimpleGatePart.java
@@ -421,7 +421,7 @@ public abstract class SimpleGatePart extends RedstoneGatePart {
 
         @Override
         protected int cycleShape(int shape) {
-            return (shape + 1) & DELAYS.length;
+            return (shape + 1) % DELAYS.length;
         }
 
         @Override


### PR DESCRIPTION
* Fixed Timer gates loading elapsed progress incorrectly on world load, causing every timer to synchronize 
* Fixed State cells and Counters not rendering pointer model reflected
* Fixed Repeater unable to cycle delay passed 4 ticks
* Fixed accidental static variable in Gate Renderer, causing different threads to race on shared model states instead of it being thread-local