### PR TITLE
Fix Transmission APIs not correctly providing bundled signals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ Thumbs.db
 /build/
 /*/build/
 /run/
+/*/run/
 /projectFilesBackup/
 #IDEA files from Gradle
 .idea/

--- a/README.md
+++ b/README.md
@@ -12,33 +12,25 @@ A Minecraft Forge mod all about Redstone circuity.
 
 ## Development Environment Setup
 
-Project Red uses a standard Forge Gradle environment. Setup steps should be the same as most other mods:
+Project Red uses a standard Forge Gradle environment. Setup steps should be the same as most other mods. Instructions below are for Intellij IDEA, but the process is very similar for both Eclipse and VSCode. See [Forge Gradle](https://docs.minecraftforge.net/en/fg-5.x/gettingstarted/#setting-up-forgegradle) docs for more info.
 
 1. Create a new folder and check out the repository:
    ```
    mkdir ~/projectred && cd ~/projectred
    git checkout https://github.com/MrTJP/ProjectRed.git .
    ```
-2. Setup a new workspace with a decompiled copy of Minecraft:
-   ```
-   ./gradlew setupDecompWorkspace
-   ```
-3. You can now either set up Eclipse or IntelliJ Idea as your IDE.
 
-   For Eclipse:
-   * Generate an Eclipse project with `./gradlew eclipse`
-   * Import the generated project with `File > Import > General > Existing Projects into Workspace` 
-    
-   For Intellij Idea:
-   * Open IntelliJ and from the splash screen, select `Import Project`
-   * Point IntelliJ to the `./build.gradle` file in the git repo
-   * Close IntelliJ and run `./gradlew genIntellijRuns` to complete setup
+2. Build the project: 
+   ```
+   ./gradlew build
+   ```   
+
+3. Generate run configurations:
+   ```
+   ./gradlew genIntellijRuns
+   ```
    
-4. If you'd like to contribute changes, you'll need to create your own fork of ProjectRed, push your changes, and then open a Pull Request for review.
+4. Open the project directory in Intellij IDEA and give it a few minutes to set up and index the Gradle project.
 
 ### Building Locally
-You can build a locally checked out copy of the repository by simply running:
-```
-./gradlew build
-```
-The built jars will be found in `./build/libs`.
+You can re-build jar files locally by running `./gradlew build`. The jars can be found in `./<module>/build/libs`.

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -9,19 +9,12 @@ minecraft {
     mappings channel: mcp_mappings, version: mc_version
     accessTransformer = file("src/main/resources/META-INF/accesstransformer.cfg")
     runs {
-        client {
-            workingDirectory file('run')
-            mods {
-                '${mod_id}' { source sourceSets.main }
-            }
-        }
-        server {
-            workingDirectory file('run')
-            mods {
-                '${mod_id}' { source sourceSets.main }
-            }
-        }
-        datagen {
+        data {
+            property 'mixin.env.remapRefMap', 'true'
+            property 'mixin.env.refMapRemappingFile', "${buildDir}/createSrgToMcp/output.srg"
+
+            ideaModule "${rootProject.name}.${project.name}.main"
+
             workingDirectory file('run')
             args '--mod', mod_id, '--all', '--output', file("src/main/generated"), '--existing', file("src/main/resources")
             mods {

--- a/core/src/main/resources/META-INF/accesstransformer.cfg
+++ b/core/src/main/resources/META-INF/accesstransformer.cfg
@@ -17,3 +17,6 @@ public net.minecraft.world.inventory.AbstractContainerMenu m_182420_(II)V # upda
 public net.minecraft.world.phys.shapes.VoxelShape <init>(Lnet/minecraft/world/phys/shapes/DiscreteVoxelShape;)V # <init>
 public net.minecraft.world.phys.shapes.VoxelShape f_83211_ # shape
 public net.minecraft.world.phys.shapes.VoxelShape m_7700_(Lnet/minecraft/core/Direction$Axis;)Lit/unimi/dsi/fastutil/doubles/DoubleList; # getCoords
+public net.minecraft.world.phys.shapes.SliceShape m_7700_(Lnet/minecraft/core/Direction$Axis;)Lit/unimi/dsi/fastutil/doubles/DoubleList; # getCoords
+public net.minecraft.world.phys.shapes.ArrayVoxelShape m_7700_(Lnet/minecraft/core/Direction$Axis;)Lit/unimi/dsi/fastutil/doubles/DoubleList; # getCoords
+public net.minecraft.world.phys.shapes.CubeVoxelShape m_7700_(Lnet/minecraft/core/Direction$Axis;)Lit/unimi/dsi/fastutil/doubles/DoubleList; # getCoords

--- a/expansion/build.gradle
+++ b/expansion/build.gradle
@@ -4,25 +4,18 @@ plugins {
     id 'org.spongepowered.mixin'
 }
 
-String mod_id = 'projectred-expansion'
+String mod_id = 'projectred_expansion'
 
 minecraft {
     mappings channel: mcp_mappings, version: mc_version
     accessTransformer = file("../core/src/main/resources/META-INF/accesstransformer.cfg")
     runs {
-        client {
-            workingDirectory file('run')
-            mods {
-                '${mod_id}' { source sourceSets.main }
-            }
-        }
-        server {
-            workingDirectory file('run')
-            mods {
-                '${mod_id}' { source sourceSets.main }
-            }
-        }
-        datagen {
+        data {
+            property 'mixin.env.remapRefMap', 'true'
+            property 'mixin.env.refMapRemappingFile', "${buildDir}/createSrgToMcp/output.srg"
+
+            ideaModule "${rootProject.name}.${project.name}.main"
+
             workingDirectory file('run')
             args '--mod', mod_id, '--all', '--output', file("src/main/generated"), '--existing', file("src/main/resources")
             mods {
@@ -40,7 +33,7 @@ dependencies {
     implementation fg.deobf("codechicken:CodeChickenLib:${mc_version}-${ccl_version}:universal")
     implementation fg.deobf("codechicken:CBMultipart:${mc_version}-${cbm_version}:universal")
 
-    compileOnly project(":core")
+    implementation project(":core")
 }
 
 mixin {

--- a/exploration/build.gradle
+++ b/exploration/build.gradle
@@ -3,25 +3,18 @@ plugins {
     id 'com.matthewprenger.cursegradle'
 }
 
-String mod_id = 'projectred-exploration'
+String mod_id = 'projectred_exploration'
 
 minecraft {
     mappings channel: mcp_mappings, version: mc_version
     accessTransformer = file("../core/src/main/resources/META-INF/accesstransformer.cfg")
     runs {
-        client {
-            workingDirectory file('run')
-            mods {
-                '${mod_id}' { source sourceSets.main }
-            }
-        }
-        server {
-            workingDirectory file('run')
-            mods {
-                '${mod_id}' { source sourceSets.main }
-            }
-        }
-        datagen {
+        data {
+            property 'mixin.env.remapRefMap', 'true'
+            property 'mixin.env.refMapRemappingFile', "${buildDir}/createSrgToMcp/output.srg"
+
+            ideaModule "${rootProject.name}.${project.name}.main"
+
             workingDirectory file('run')
             args '--mod', mod_id, '--all', '--output', file("src/main/generated"), '--existing', file("src/main/resources")
             mods {
@@ -37,7 +30,7 @@ dependencies {
     implementation fg.deobf("codechicken:CodeChickenLib:${mc_version}-${ccl_version}:universal")
     implementation fg.deobf("codechicken:CBMultipart:${mc_version}-${cbm_version}:universal")
 
-    compileOnly project(":core")
+    implementation project(":core")
 }
 
 curseforge {

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,3 +11,5 @@ jei_version=10.2.1.+
 cct_version=1.101.2
 
 fabrication_version=0.1.0-alpha-15
+
+org.gradle.jvmargs=-Xmx4096M

--- a/illumination/build.gradle
+++ b/illumination/build.gradle
@@ -3,25 +3,18 @@ plugins {
     id 'com.matthewprenger.cursegradle'
 }
 
-String mod_id = 'projectred-illumination'
+String mod_id = 'projectred_illumination'
 
 minecraft {
     mappings channel: mcp_mappings, version: mc_version
     accessTransformer = file("../core/src/main/resources/META-INF/accesstransformer.cfg")
     runs {
-        client {
-            workingDirectory file('run')
-            mods {
-                '${mod_id}' { source sourceSets.main }
-            }
-        }
-        server {
-            workingDirectory file('run')
-            mods {
-                '${mod_id}' { source sourceSets.main }
-            }
-        }
-        datagen {
+        data {
+            property 'mixin.env.remapRefMap', 'true'
+            property 'mixin.env.refMapRemappingFile', "${buildDir}/createSrgToMcp/output.srg"
+
+            ideaModule "${rootProject.name}.${project.name}.main"
+
             workingDirectory file('run')
             args '--mod', mod_id, '--all', '--output', file("src/main/generated"), '--existing', file("src/main/resources")
             mods {
@@ -37,7 +30,7 @@ dependencies {
     implementation fg.deobf("codechicken:CodeChickenLib:${mc_version}-${ccl_version}:universal")
     implementation fg.deobf("codechicken:CBMultipart:${mc_version}-${cbm_version}:universal")
 
-    compileOnly project(":core")
+    implementation project(":core")
 }
 
 curseforge {

--- a/integration/build.gradle
+++ b/integration/build.gradle
@@ -3,25 +3,18 @@ plugins {
     id 'com.matthewprenger.cursegradle'
 }
 
-String mod_id = 'projectred-integration'
+String mod_id = 'projectred_integration'
 
 minecraft {
     mappings channel: mcp_mappings, version: mc_version
     accessTransformer = file("src/main/resources/META-INF/accesstransformer.cfg")
     runs {
-        client {
-            workingDirectory file('run')
-            mods {
-                '${mod_id}' { source sourceSets.main }
-            }
-        }
-        server {
-            workingDirectory file('run')
-            mods {
-                '${mod_id}' { source sourceSets.main }
-            }
-        }
-        datagen {
+        data {
+            property 'mixin.env.remapRefMap', 'true'
+            property 'mixin.env.refMapRemappingFile', "${buildDir}/createSrgToMcp/output.srg"
+
+            ideaModule "${rootProject.name}.${project.name}.main"
+
             workingDirectory file('run')
             args '--mod', mod_id, '--all', '--output', file("src/main/generated"), '--existing', file("src/main/resources")
             mods {
@@ -37,7 +30,7 @@ dependencies {
     implementation fg.deobf("codechicken:CodeChickenLib:${mc_version}-${ccl_version}:universal")
     implementation fg.deobf("codechicken:CBMultipart:${mc_version}-${cbm_version}:universal")
 
-    compileOnly project(":core")
+    implementation project(":core")
 }
 
 curseforge {

--- a/integration/src/main/java/mrtjp/projectred/integration/part/BundledGatePart.java
+++ b/integration/src/main/java/mrtjp/projectred/integration/part/BundledGatePart.java
@@ -86,7 +86,7 @@ public abstract class BundledGatePart extends RedstoneGatePart implements IBundl
             return ((IBundledTile) lookup.tile).getBundledSignal(Rotation.rotateSide(lookup.otherSide, lookup.otherRotation));
 
         } else if (lookup.tile != null) {
-            return BundledSignalsLib.getBundledSignalViaInteraction(lookup.tile.getLevel(), lookup.tile.getBlockPos(), Direction.values()[lookup.r]);
+            return BundledSignalsLib.getBundledSignalViaInteraction(lookup.tile.getLevel(), lookup.tile.getBlockPos(), Direction.values()[Rotation.rotateSide(lookup.otherSide, lookup.otherRotation)]);
         }
         return null;
     }

--- a/runtime/build.gradle
+++ b/runtime/build.gradle
@@ -1,0 +1,51 @@
+/**
+ * Used only for generating run configs that include all ProjectRed modules in the classpath.
+ */
+plugins {
+    id 'net.minecraftforge.gradle'
+    id 'org.spongepowered.mixin'
+}
+
+minecraft {
+    mappings channel: mcp_mappings, version: mc_version
+    accessTransformer = file("../core/src/main/resources/META-INF/accesstransformer.cfg")
+
+    runs {
+        configureEach {
+            ideaModule "${rootProject.name}.${project.name}.main"
+
+            mods {
+                'projectred_core' { source project(":core").sourceSets.main }
+                'projectred_expansion' { source project(":expansion").sourceSets.main }
+                'projectred_exploration' { source project(":exploration").sourceSets.main }
+                'projectred_illumination' { source project(":illumination").sourceSets.main }
+                'projectred_integration' { source project(":integration").sourceSets.main }
+                'projectred_transmission' { source project(":transmission").sourceSets.main }
+            }
+        }
+
+        client {
+            workingDirectory file('run')
+        }
+
+        server {
+            workingDirectory file('run_server')
+        }
+    }
+}
+
+dependencies {
+    minecraft "net.minecraftforge:forge:${mc_version}-${forge_version}"
+
+    runtimeOnly project(":core")
+    runtimeOnly project(":expansion")
+    runtimeOnly project(":exploration")
+    runtimeOnly project(":illumination")
+    runtimeOnly project(":integration")
+    runtimeOnly project(":transmission")
+}
+
+mixin {
+    debug.verbose = true
+    debug.export = true
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,4 +17,8 @@ pluginManagement {
 
 rootProject.name = 'ProjectRed'
 
+// Mod modules
 include 'core', 'expansion', 'exploration', 'illumination', 'integration', 'transmission'
+
+// Empty module for client/server run configurations
+include 'runtime'

--- a/transmission/build.gradle
+++ b/transmission/build.gradle
@@ -5,25 +5,18 @@ plugins {
 
 apply plugin: 'net.minecraftforge.gradle'
 
-String mod_id = 'projectred-transmission'
+String mod_id = 'projectred_transmission'
 
 minecraft {
     mappings channel: mcp_mappings, version: mc_version
     accessTransformer = file("src/main/resources/META-INF/accesstransformer.cfg")
     runs {
-        client {
-            workingDirectory file('run')
-            mods {
-                '${mod_id}' { source sourceSets.main }
-            }
-        }
-        server {
-            workingDirectory file('run')
-            mods {
-                '${mod_id}' { source sourceSets.main }
-            }
-        }
-        datagen {
+        data {
+            property 'mixin.env.remapRefMap', 'true'
+            property 'mixin.env.refMapRemappingFile', "${buildDir}/createSrgToMcp/output.srg"
+
+            ideaModule "${rootProject.name}.${project.name}.main"
+
             workingDirectory file('run')
             args '--mod', mod_id, '--all', '--output', file("src/main/generated"), '--existing', file("src/main/resources")
             mods {
@@ -39,24 +32,24 @@ dependencies {
     implementation fg.deobf("codechicken:CodeChickenLib:${mc_version}-${ccl_version}:universal")
     implementation fg.deobf("codechicken:CBMultipart:${mc_version}-${cbm_version}:universal")
 
-    compileOnly project(":core")
+    implementation project(":core")
 }
 
 curseforge {
- apiKey = System.getenv('CURSE_TOKEN') ?: 'XXX'
+    apiKey = System.getenv('CURSE_TOKEN') ?: 'XXX'
 
- // Transmission
- project {
-     id = '478939'
-     releaseType = System.getenv('CURSE_RELEASE_TYPE') ?: 'alpha'
-     changelogType = 'markdown'
-     changelog = rootProject.file('CHANGELOG.md')
-     relations {
-         requiredDependency 'project-red-core'
-     }
+    // Transmission
+    project {
+        id = '478939'
+        releaseType = System.getenv('CURSE_RELEASE_TYPE') ?: 'alpha'
+        changelogType = 'markdown'
+        changelog = rootProject.file('CHANGELOG.md')
+        relations {
+            requiredDependency 'project-red-core'
+        }
 
-     // Java/ForgeGradle integrations don't work after 1.18.2 port
-     addGameVersion "${mc_version}"
-     addGameVersion "Java ${java_lang_version}"
- }
+        // Java/ForgeGradle integrations don't work after 1.18.2 port
+        addGameVersion "${mc_version}"
+        addGameVersion "Java ${java_lang_version}"
+    }
 }

--- a/transmission/src/main/java/mrtjp/projectred/transmission/TransmissionAPI.java
+++ b/transmission/src/main/java/mrtjp/projectred/transmission/TransmissionAPI.java
@@ -32,39 +32,7 @@ public class TransmissionAPI implements ITransmissionAPI {
 
     @Override
     public byte[] getBundledInput(Level world, BlockPos pos, Direction facing) {
-
-        int side = facing.ordinal();
-        BlockEntity tile = world.getBlockEntity(pos);
-
-        if (tile instanceof IBundledTile) {
-            return ((IBundledTile) tile).getBundledSignal(side ^ 1);
-        }
-
-        if (tile instanceof TileMultipart) {
-            // Try to source bundled signals from ALL parts capable of outputting to the queried side.
-            // This includes 4 face parts perpendicular to the queried side, and the center part.
-
-            TileMultipart tmp = (TileMultipart) tile;
-            byte[] signal = null;
-
-            // Access face parts on all 4 perpendicular sides to given side
-            for (int r = 0; r < 4; r++) {
-                int pside = Rotation.rotateSide(side, r);
-                MultiPart part = tmp.getSlottedPart(pside);
-
-                if (part instanceof IBundledEmitter) {
-                    int otherRotation = Rotation.rotationTo(pside, side^1);
-                    signal = raiseSignal(signal, ((IBundledEmitter) part).getBundledSignal(otherRotation));
-                }
-            }
-
-            // Access center part
-            MultiPart part = tmp.getSlottedPart(6);
-            if (part instanceof IBundledEmitter) {
-                signal = raiseSignal(signal, ((IBundledEmitter) part).getBundledSignal(side ^ 1));
-            }
-        }
-        return null;
+        return BundledSignalsLib.getBundledInput(world, pos, facing);
     }
 
     @Override

--- a/transmission/src/main/java/mrtjp/projectred/transmission/part/BundledCablePart.java
+++ b/transmission/src/main/java/mrtjp/projectred/transmission/part/BundledCablePart.java
@@ -231,7 +231,7 @@ public class BundledCablePart extends BaseFaceWirePart implements IBundledCableP
             raiseSignal(tmpSignal, signalIn);
 
         } else if (lookup.tile != null) {
-            byte[] externalSignal = BundledSignalsLib.getBundledSignalViaInteraction(lookup.tile.getLevel(), lookup.tile.getBlockPos(), Direction.values()[lookup.r]);
+            byte[] externalSignal = BundledSignalsLib.getBundledSignalViaInteraction(lookup.tile.getLevel(), lookup.tile.getBlockPos(), Direction.values()[Rotation.rotateSide(lookup.otherSide, lookup.otherRotation)]);
             raiseSignal(tmpSignal, externalSignal);
         }
     }


### PR DESCRIPTION
* Fixed `ITransmissionAPI#getBundledInput` always returning null
* Fixed Bundled cables and bundled gates querying registered Bundled Interactions with incorrect side
* Fixed dev environment run configurations
* Updated dev environment setup instructions

Fixes #1785 and #1786 