### PR TITLE
Bug fixes

### DIFF
--- a/core/src/main/generated/data/minecraft/tags/blocks/mineable/pickaxe.json
+++ b/core/src/main/generated/data/minecraft/tags/blocks/mineable/pickaxe.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "projectred_core:electrotine_generator"
+  ]
+}

--- a/core/src/main/java/mrtjp/projectred/core/ProjectRedCore.java
+++ b/core/src/main/java/mrtjp/projectred/core/ProjectRedCore.java
@@ -93,6 +93,7 @@ public class ProjectRedCore {
             generator.addProvider(new CoreRecipeProvider(generator));
             generator.addProvider(new CoreLootTableProvider(generator));
             generator.addProvider(new CoreItemTagsProvider(generator, fileHelper));
+            generator.addProvider(new CoreBlockTagsProvider(generator, fileHelper));
         }
     }
 }

--- a/core/src/main/java/mrtjp/projectred/core/data/CoreBlockTagsProvider.java
+++ b/core/src/main/java/mrtjp/projectred/core/data/CoreBlockTagsProvider.java
@@ -1,0 +1,31 @@
+package mrtjp.projectred.core.data;
+
+import net.minecraft.data.DataGenerator;
+import net.minecraft.data.tags.BlockTagsProvider;
+import net.minecraft.tags.BlockTags;
+import net.minecraftforge.common.data.ExistingFileHelper;
+import org.jetbrains.annotations.Nullable;
+
+import static mrtjp.projectred.core.ProjectRedCore.MOD_ID;
+
+import static mrtjp.projectred.core.init.CoreReferences.*;
+
+public class CoreBlockTagsProvider extends BlockTagsProvider {
+
+    public CoreBlockTagsProvider(DataGenerator gen, @Nullable ExistingFileHelper existingFileHelper) {
+        super(gen, MOD_ID, existingFileHelper);
+    }
+
+    @Override
+    public String getName() {
+        return "ProjectRed-Core Block Tags";
+    }
+
+    @Override
+    protected void addTags() {
+
+        tag(BlockTags.MINEABLE_WITH_PICKAXE)
+                .add(ELECTROTINE_GENERATOR_BLOCK);
+
+    }
+}

--- a/core/src/main/java/mrtjp/projectred/core/tile/ElectrotineGeneratorTile.java
+++ b/core/src/main/java/mrtjp/projectred/core/tile/ElectrotineGeneratorTile.java
@@ -4,6 +4,7 @@ import codechicken.lib.util.ServerUtils;
 import codechicken.lib.vec.Vector3;
 import mrtjp.projectred.api.IConnectable;
 import mrtjp.projectred.core.block.ProjectRedBlock;
+import mrtjp.projectred.core.inventory.BaseInventory;
 import mrtjp.projectred.core.inventory.container.ElectrotineGeneratorContainer;
 import mrtjp.projectred.core.power.ILowLoadMachine;
 import mrtjp.projectred.core.power.ILowLoadPowerLine;
@@ -52,7 +53,7 @@ public class ElectrotineGeneratorTile extends BasePoweredTile implements ILowLoa
     public void saveToNBT(CompoundTag tag) {
         super.saveToNBT(tag);
         conductor.save(tag);
-        tag.put("inventory", inventory.createTag());
+        inventory.saveTo(tag, "inventory");
         tag.putInt("burnTime", burnTimeRemaining);
         tag.putInt("stored", powerStored);
     }
@@ -61,7 +62,7 @@ public class ElectrotineGeneratorTile extends BasePoweredTile implements ILowLoa
     public void loadFromNBT(CompoundTag tag) {
         super.loadFromNBT(tag);
         conductor.load(tag);
-        inventory.fromTag(tag.getList("inventory", 10));
+        inventory.loadFrom(tag, "inventory");
         burnTimeRemaining = tag.getInt("burnTime");
         powerStored = tag.getInt("stored");
     }
@@ -235,7 +236,7 @@ public class ElectrotineGeneratorTile extends BasePoweredTile implements ILowLoa
     }
     //endregion
 
-    private static class ElectrotineGeneratorInventory extends SimpleContainer {
+    private static class ElectrotineGeneratorInventory extends BaseInventory {
 
         public ElectrotineGeneratorInventory() {
             super(1);

--- a/expansion/src/main/java/mrtjp/projectred/expansion/tile/AutoCrafterTile.java
+++ b/expansion/src/main/java/mrtjp/projectred/expansion/tile/AutoCrafterTile.java
@@ -3,6 +3,7 @@ package mrtjp.projectred.expansion.tile;
 import codechicken.lib.data.MCDataInput;
 import codechicken.lib.data.MCDataOutput;
 import codechicken.lib.vec.Vector3;
+import mrtjp.projectred.core.inventory.BaseInventory;
 import mrtjp.projectred.expansion.CraftingHelper;
 import mrtjp.projectred.expansion.init.ExpansionReferences;
 import mrtjp.projectred.expansion.inventory.container.AutoCrafterContainer;
@@ -23,14 +24,14 @@ public class AutoCrafterTile extends BaseMachineTile implements CraftingHelper.I
 
     private static final int KEY_CYCLE_PLAN = 2;
 
-    private final SimpleContainer planInventory = new SimpleContainer(9) {
+    private final BaseInventory planInventory = new BaseInventory(9) {
         @Override
         public boolean canPlaceItem(int slot, ItemStack stack) {
             return RecipePlanItem.hasRecipeInside(stack);
         }
     };
-    private final SimpleContainer storageInventory = new SimpleContainer(18);
-    private final SimpleContainer craftingGrid = new SimpleContainer(9);
+    private final BaseInventory storageInventory = new BaseInventory(18);
+    private final BaseInventory craftingGrid = new BaseInventory(9);
 
     private final CraftingHelper craftingHelper = new CraftingHelper(this);
 
@@ -47,16 +48,16 @@ public class AutoCrafterTile extends BaseMachineTile implements CraftingHelper.I
     @Override
     public void saveToNBT(CompoundTag tag) {
         super.saveToNBT(tag);
-        tag.put("storage_inv", storageInventory.createTag());
-        tag.put("plan_inv", planInventory.createTag());
+        storageInventory.saveTo(tag, "storage_inv");
+        planInventory.saveTo(tag, "plan_inv");
         tag.putByte("plan_slot", (byte) planSlot);
     }
 
     @Override
     public void loadFromNBT(CompoundTag tag) {
         super.loadFromNBT(tag);
-        storageInventory.fromTag(tag.getList("storage_inv", 10));
-        planInventory.fromTag(tag.getList("plan_inv", 10));
+        storageInventory.loadFrom(tag, "storage_inv");
+        planInventory.loadFrom(tag, "plan_inv");
         planSlot = tag.getByte("plan_slot") & 0xFF;
     }
 

--- a/expansion/src/main/java/mrtjp/projectred/expansion/tile/BatteryBoxTile.java
+++ b/expansion/src/main/java/mrtjp/projectred/expansion/tile/BatteryBoxTile.java
@@ -4,7 +4,7 @@ import codechicken.lib.data.MCDataInput;
 import codechicken.lib.data.MCDataOutput;
 import codechicken.lib.util.ServerUtils;
 import codechicken.lib.vec.Vector3;
-import mrtjp.projectred.expansion.ProjectRedExpansion;
+import mrtjp.projectred.core.inventory.BaseInventory;
 import mrtjp.projectred.expansion.block.BatteryBoxBlock;
 import mrtjp.projectred.expansion.init.ExpansionReferences;
 import mrtjp.projectred.expansion.inventory.container.BatteryBoxContainer;
@@ -51,14 +51,14 @@ public class BatteryBoxTile extends LowLoadPoweredTile {
     public void saveToNBT(CompoundTag tag) {
         super.saveToNBT(tag);
         tag.putInt("storage", powerStored);
-        tag.put("inventory", inventory.createTag());
+        inventory.saveTo(tag, "inventory");
     }
 
     @Override
     public void loadFromNBT(CompoundTag tag) {
         super.loadFromNBT(tag);
         powerStored = tag.getInt("storage");
-        inventory.fromTag(tag.getList("inventory", 10));
+        inventory.loadFrom(tag, "inventory");
     }
 
     @Override
@@ -232,7 +232,7 @@ public class BatteryBoxTile extends LowLoadPoweredTile {
     }
     //endregion
 
-    private static class BatteryBoxInventory extends SimpleContainer implements WorldlyContainer {
+    private static class BatteryBoxInventory extends BaseInventory implements WorldlyContainer {
 
         private static final int[] TOP_SLOTS = new int[]{0};
         private static final int[] BOTTOM_SLOTS = new int[]{1};

--- a/expansion/src/main/java/mrtjp/projectred/expansion/tile/BatteryBoxTile.java
+++ b/expansion/src/main/java/mrtjp/projectred/expansion/tile/BatteryBoxTile.java
@@ -30,6 +30,7 @@ import net.minecraftforge.items.wrapper.SidedInvWrapper;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import static mrtjp.projectred.expansion.ProjectRedExpansion.LOGGER;
 import static mrtjp.projectred.expansion.init.ExpansionReferences.BATTERY_BOX_BLOCK;
 
 public class BatteryBoxTile extends LowLoadPoweredTile {
@@ -136,6 +137,13 @@ public class BatteryBoxTile extends LowLoadPoweredTile {
         // Charge and discharge items in inventory
         changed |= tryChargeBattery();
         changed |= tryDischargeBattery();
+
+        // Sanity check powerStored
+        // TODO Remove: temporary mitigation for #1789
+        if (powerStored < 0) {
+            LOGGER.warn("Power stored is negative! BatteryBoxTile @{}", getBlockPos());
+            powerStored = 0;
+        }
 
         // Update block state if render level changed
         int prevPowerLevel = getBlockState().getValue(BatteryBoxBlock.CHARGE_LEVEL);

--- a/expansion/src/main/java/mrtjp/projectred/expansion/tile/BatteryBoxTile.java
+++ b/expansion/src/main/java/mrtjp/projectred/expansion/tile/BatteryBoxTile.java
@@ -4,6 +4,7 @@ import codechicken.lib.data.MCDataInput;
 import codechicken.lib.data.MCDataOutput;
 import codechicken.lib.util.ServerUtils;
 import codechicken.lib.vec.Vector3;
+import mrtjp.projectred.expansion.ProjectRedExpansion;
 import mrtjp.projectred.expansion.block.BatteryBoxBlock;
 import mrtjp.projectred.expansion.init.ExpansionReferences;
 import mrtjp.projectred.expansion.inventory.container.BatteryBoxContainer;
@@ -43,6 +44,7 @@ public class BatteryBoxTile extends LowLoadPoweredTile {
 
     public BatteryBoxTile(BlockPos pos, BlockState state) {
         super(ExpansionReferences.BATTERY_BOX_TILE, pos, state);
+        inventory.addListener(c -> setChanged());
     }
 
     @Override

--- a/expansion/src/main/java/mrtjp/projectred/expansion/tile/ChargingBenchTile.java
+++ b/expansion/src/main/java/mrtjp/projectred/expansion/tile/ChargingBenchTile.java
@@ -5,6 +5,7 @@ import codechicken.lib.data.MCDataOutput;
 import codechicken.lib.util.ServerUtils;
 import codechicken.lib.vec.Vector3;
 import mrtjp.projectred.core.block.ProjectRedBlock;
+import mrtjp.projectred.core.inventory.BaseInventory;
 import mrtjp.projectred.expansion.init.ExpansionReferences;
 import mrtjp.projectred.expansion.inventory.container.ChargingBenchContainer;
 import mrtjp.projectred.expansion.item.IChargable;
@@ -47,7 +48,7 @@ public class ChargingBenchTile extends LowLoadPoweredTile {
         super.saveToNBT(tag);
         tag.putInt("storage", powerStored);
         tag.putByte("chargeSlot", (byte) chargeSlot);
-        tag.put("inventory", inventory.createTag());
+        inventory.saveTo(tag, "inventory");
     }
 
     @Override
@@ -55,7 +56,7 @@ public class ChargingBenchTile extends LowLoadPoweredTile {
         super.loadFromNBT(tag);
         powerStored = tag.getInt("storage");
         chargeSlot = tag.getByte("chargeSlot") & 0xFF;
-        inventory.fromTag(tag.getList("inventory", 10));
+        inventory.loadFrom(tag, "inventory");
     }
 
     @Override
@@ -200,7 +201,7 @@ public class ChargingBenchTile extends LowLoadPoweredTile {
     }
     //endregion
 
-    private static class ChargingBenchInventory extends SimpleContainer implements WorldlyContainer {
+    private static class ChargingBenchInventory extends BaseInventory implements WorldlyContainer {
 
         private static final int[] TOP_SLOTS = new int[8];
         private static final int[] BOTTOM_SLOTS = new int[8];

--- a/expansion/src/main/java/mrtjp/projectred/expansion/tile/ChargingBenchTile.java
+++ b/expansion/src/main/java/mrtjp/projectred/expansion/tile/ChargingBenchTile.java
@@ -39,6 +39,7 @@ public class ChargingBenchTile extends LowLoadPoweredTile {
 
     public ChargingBenchTile(BlockPos pos, BlockState state) {
         super(ExpansionReferences.CHARGING_BENCH_TILE, pos, state);
+        inventory.addListener(c -> setChanged());
     }
 
     @Override

--- a/expansion/src/main/java/mrtjp/projectred/expansion/tile/ProjectBenchTile.java
+++ b/expansion/src/main/java/mrtjp/projectred/expansion/tile/ProjectBenchTile.java
@@ -4,7 +4,7 @@ import codechicken.lib.data.MCDataInput;
 import codechicken.lib.data.MCDataOutput;
 import codechicken.lib.util.ServerUtils;
 import codechicken.lib.vec.Vector3;
-import codechicken.multipart.api.TickableTile;
+import mrtjp.projectred.core.inventory.BaseInventory;
 import mrtjp.projectred.core.tile.IPacketReceiverTile;
 import mrtjp.projectred.core.tile.ProjectRedTile;
 import mrtjp.projectred.expansion.CraftingHelper;
@@ -37,15 +37,15 @@ public class ProjectBenchTile extends ProjectRedTile implements IPacketReceiverT
     private static final int KEY_WRITE_PLAN = 2;
     private static final int KEY_CLEAR_GRID = 3;
 
-    private final SimpleContainer planInventory = new SimpleContainer(1) {
+    private final BaseInventory planInventory = new BaseInventory(1) {
         @Override
         public boolean canPlaceItem(int slot, ItemStack stack) {
             return stack.getItem() instanceof RecipePlanItem;
         }
     };
-    private final SimpleContainer craftingGrid = new SimpleContainer(9);
-    private final SimpleContainer storageInventory = new SimpleContainer(18);
-    private final SimpleContainer planCraftingGrid = new SimpleContainer(9);
+    private final BaseInventory craftingGrid = new BaseInventory(9);
+    private final BaseInventory storageInventory = new BaseInventory(18);
+    private final BaseInventory planCraftingGrid = new BaseInventory(9);
 
     private final CraftingHelper craftingHelper = new CraftingHelper(this);
     private final LazyOptional<?> storageInventoryCap = LazyOptional.of(this::createStorageInventoryCap);
@@ -64,18 +64,18 @@ public class ProjectBenchTile extends ProjectRedTile implements IPacketReceiverT
 
     @Override
     public void saveToNBT(CompoundTag tag) {
-        tag.put("plan_inv", planInventory.createTag());
-        tag.put("crafting_inv", craftingGrid.createTag());
-        tag.put("storage_inv", storageInventory.createTag());
-        tag.put("plan_crafting_inv", planCraftingGrid.createTag());
+        planInventory.saveTo(tag, "plan_inv");
+        craftingGrid.saveTo(tag, "crafting_inv");
+        storageInventory.saveTo(tag, "storage_inv");
+        planCraftingGrid.saveTo(tag, "plan_crafting_inv");
     }
 
     @Override
     public void loadFromNBT(CompoundTag tag) {
-        planInventory.fromTag(tag.getList("plan_inv", 10));
-        craftingGrid.fromTag(tag.getList("crafting_inv", 10));
-        storageInventory.fromTag(tag.getList("storage_inv", 10));
-        planCraftingGrid.fromTag(tag.getList("plan_crafting_inv", 10));
+        planInventory.loadFrom(tag, "plan_inv");
+        craftingGrid.loadFrom(tag, "crafting_inv");
+        storageInventory.loadFrom(tag, "storage_inv");
+        planCraftingGrid.loadFrom(tag, "plan_crafting_inv");
     }
 
     @Override


### PR DESCRIPTION
* Fix Battery box and Charging bench not marking chunk for saving when container contents change, resulting in newly placed items sometimes not saving.
* Save container items in a way that preserves ordering for all blocks
* Fix Electrotine generator not having pickaxe assigned as breaking tool
* Prevent map corruption by checking for a negative power stored value in battery boxes. Root cause is not yet known. (Fixes #1789)