### PR TITLE
Bug fixes for 1.18

### DIFF
--- a/core/src/main/java/mrtjp/projectred/core/BundledSignalsLib.java
+++ b/core/src/main/java/mrtjp/projectred/core/BundledSignalsLib.java
@@ -186,9 +186,9 @@ public class BundledSignalsLib {
 
     public static int mostSignificantBit(int mask) {
         int idx = 0;
-        int m2 = mask >> 1;
+        int m2 = mask >>> 1;
         while (m2 != 0) {
-            m2 >>= 1;
+            m2 >>>= 1;
             idx++;
         }
         return idx;

--- a/exploration/src/main/java/mrtjp/projectred/exploration/init/ExplorationWorldFeatures.java
+++ b/exploration/src/main/java/mrtjp/projectred/exploration/init/ExplorationWorldFeatures.java
@@ -100,7 +100,7 @@ public class ExplorationWorldFeatures {
     // Registers the actual ore feature. This describes a single cluster of this specific ore type
     private static Holder<ConfiguredFeature<OreConfiguration, ?>> registerOreConfiguration(String id, Block standard, Block deepslate, int veinSize) {
         return FeatureUtils.register(
-                id,
+                modId(id),
                 Feature.ORE,
                 new OreConfiguration(ImmutableList.of(
                         OreConfiguration.target(OreFeatures.STONE_ORE_REPLACEABLES, standard.defaultBlockState()),
@@ -115,7 +115,7 @@ public class ExplorationWorldFeatures {
                 HeightRangePlacement.triangle(VerticalAnchor.absolute(minY), VerticalAnchor.absolute(maxY)));
 
         return PlacementUtils.register(
-                id,
+                modId(id),
                 configuredFeature,
                 modifiers);
     }
@@ -135,5 +135,9 @@ public class ExplorationWorldFeatures {
                 BuiltinRegistries.CONFIGURED_CARVER,
                 new ResourceLocation(MOD_ID, ID_MARBLE_CAVE_CARVER),
                 configuredCarver);
+    }
+
+    private static String modId(String id) {
+        return MOD_ID + ":" + id;
     }
 }

--- a/exploration/src/main/java/mrtjp/projectred/exploration/inventory/BackpackInventory.java
+++ b/exploration/src/main/java/mrtjp/projectred/exploration/inventory/BackpackInventory.java
@@ -20,6 +20,7 @@ public class BackpackInventory extends BaseInventory {
             load(inventoryTag);
             // Delete inventory from stack. It will be saved back once container closes
             BackpackItem.deleteBackpackInventory(backpack);
+            BackpackItem.setBackpackOpenedFlag(backpack, true);
         }
     }
 
@@ -29,6 +30,7 @@ public class BackpackInventory extends BaseInventory {
             CompoundTag inventoryTag = new CompoundTag();
             save(inventoryTag);
             BackpackItem.saveBackpackInventory(backpack, inventoryTag);
+            BackpackItem.setBackpackOpenedFlag(backpack, false);
         }
     }
 

--- a/exploration/src/main/java/mrtjp/projectred/exploration/item/BackpackItem.java
+++ b/exploration/src/main/java/mrtjp/projectred/exploration/item/BackpackItem.java
@@ -25,10 +25,12 @@ import net.minecraft.world.level.Level;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Objects;
 
 public class BackpackItem extends Item {
 
     public static final String TAG_INVENTORY = "backpack_inventory";
+    public static final String TAG_IS_OPENED = "is_opened";
 
     private final int colour;
 
@@ -67,6 +69,8 @@ public class BackpackItem extends Item {
 
     @Override
     public void appendHoverText(ItemStack stack, @Nullable Level world, List<Component> tooltip, TooltipFlag flag) {
+        if (isBackpackOpened(stack)) return;
+
         int itemCount = getBackpackItemCount(stack);
         tooltip.add(new TextComponent(itemCount + " / 27").withStyle(ChatFormatting.GRAY));
     }
@@ -105,6 +109,21 @@ public class BackpackItem extends Item {
         if (hasBackpackInventory(stack)) {
             stack.getTag().remove(TAG_INVENTORY);
         }
+    }
+
+    public static void setBackpackOpenedFlag(ItemStack stack, boolean opened) {
+        if (isBackpack(stack)) {
+            CompoundTag tag = stack.getOrCreateTag();
+            if (opened) {
+                tag.putBoolean(TAG_IS_OPENED, true);
+            } else {
+                tag.remove(TAG_IS_OPENED);
+            }
+        }
+    }
+
+    public static boolean isBackpackOpened(ItemStack stack) {
+        return isBackpack(stack) && stack.hasTag() && Objects.requireNonNull(stack.getTag()).getBoolean(TAG_IS_OPENED);
     }
 
     public static boolean isItemAllowedInBackpack(ItemStack stack) {

--- a/integration/src/main/java/mrtjp/projectred/integration/client/GateModelRenderer.java
+++ b/integration/src/main/java/mrtjp/projectred/integration/client/GateModelRenderer.java
@@ -1524,7 +1524,7 @@ public class GateModelRenderer {
 
         private final List<ComponentModel> models = new LinkedList<>();
 
-        private final WireModel[] wires = generateWireModels("xor", 4);
+        private final WireModel[] wires = generateWireModels("comparator", 4);
         private final RedstoneTorchModel torch = new RedstoneTorchModel(8, 2, 6);
         private final OnOffModel[] chips = new OnOffModel[] { new MinusChipModel(5, 8), new PlusChipModel(11, 8) };
 


### PR DESCRIPTION
* Fixed Comparator gate rendering the XOR gate surface wires
* Fixed world generation crash, particularly related to Silver Ore. Ores were accidentally being registered in the `minecraft` namespace rather than `projectred_exploration` (Fixes #1792)
* Fixed Backpack tooltip showing `0/27` while it was open (Fixes #1762)
* Fixed server freeze when using bus converter (Fixes #1809)