### PR TITLE
Bug fixing

### DIFF
--- a/core/src/main/java/mrtjp/projectred/core/part/IPropagationCenterPart.java
+++ b/core/src/main/java/mrtjp/projectred/core/part/IPropagationCenterPart.java
@@ -20,7 +20,7 @@ public interface IPropagationCenterPart extends IPropagationHooks, IConnectableC
 
                 } else if (maskConnectsOut(s)) {
                     if (!propagateTo(getStraight(s), prev, mode)) {
-                        RedstonePropagator.addNeighborChange(level(), posOfStraight(s));
+                        RedstonePropagator.addNeighborChange(level(), pos(), posOfStraight(s));
                     }
                 }
             }

--- a/core/src/main/java/mrtjp/projectred/core/part/IPropagationFacePart.java
+++ b/core/src/main/java/mrtjp/projectred/core/part/IPropagationFacePart.java
@@ -19,11 +19,11 @@ public interface IPropagationFacePart extends IPropagationHooks, IConnectableFac
                     propagateTo(getInternal(r), prev, mode);
                 } else if (maskConnectsStraight(r)) {
                     if (!propagateTo(getStraight(r), prev, mode)) {
-                        RedstonePropagator.addNeighborChange(level(), posOfStraight(r));
+                        RedstonePropagator.addNeighborChange(level(), pos(), posOfStraight(r));
                     }
                 } else if (maskConnectsCorner(r)) {
                     if (!propagateTo(getCorner(r), prev, mode)) {
-                        RedstonePropagator.addNeighborChange(level(), posOfCorner(r));
+                        RedstonePropagator.addNeighborChange(level(), posOfStraight(r), posOfCorner(r));
                     }
                 }
             }

--- a/expansion/src/main/java/mrtjp/projectred/expansion/MovementRegistry.java
+++ b/expansion/src/main/java/mrtjp/projectred/expansion/MovementRegistry.java
@@ -99,18 +99,20 @@ public class MovementRegistry {
 
             LevelChunk chunk = w.getChunkAt(pos);
             BlockState state = w.getBlockState(pos);
+
             BlockPos pos2 = pos.relative(dir);
+            LevelChunk chunk2 = w.getChunkAt(pos2);
 
             // Remove old block and tile
             silentSetBlockState(chunk, pos, Blocks.AIR.defaultBlockState());
             chunk.removeBlockEntity(pos);
 
             // Set blockstate in new position without causing blockentity creation
-            silentSetBlockState(chunk, pos2, state);
+            silentSetBlockState(chunk2, pos2, state);
 
             // Move the tile and add it back
             tmp.worldPosition = pos2;
-            chunk.addAndRegisterBlockEntity(tmp);
+            chunk2.addAndRegisterBlockEntity(tmp);
         }
 
         @Override
@@ -138,7 +140,9 @@ public class MovementRegistry {
         @Override
         public void move(Level w, BlockPos pos, Direction dir) {
             LevelChunk chunk = w.getChunkAt(pos);
+
             BlockPos pos2 = pos.relative(dir);
+            LevelChunk chunk2 = w.getChunkAt(pos2);
 
             BlockState state = w.getBlockState(pos); //ok, doesnt alert anything
             CompoundTag tag = chunk.getBlockEntityNbtForSaving(pos); // Save existing tile to nbt
@@ -148,7 +152,7 @@ public class MovementRegistry {
             chunk.removeBlockEntity(pos);
 
             // Set blockstate in new position without causing blockentity creation
-            silentSetBlockState(chunk, pos2, state);
+            silentSetBlockState(chunk2, pos2, state);
 
             if (tag != null) {
                 // Alter the tag into new position
@@ -156,7 +160,7 @@ public class MovementRegistry {
                 tag.putInt("y", pos2.getY());
                 tag.putInt("z", pos2.getZ());
                 // Add the tile back as pending
-                chunk.setBlockEntityNbt(tag);
+                chunk2.setBlockEntityNbt(tag);
             }
         }
 

--- a/integration/src/main/java/mrtjp/projectred/integration/part/ArrayGatePart.java
+++ b/integration/src/main/java/mrtjp/projectred/integration/part/ArrayGatePart.java
@@ -66,8 +66,11 @@ public abstract class ArrayGatePart extends RedstoneGatePart implements IRedwire
             }
         }
 
+        // This means change came on non-redwire side. Simply queue up a normal neighbor update
         if (uMask == 0) {
-            RedstonePropagator.addNeighborChange(level(), pos());
+            // TODO find better way to do this and sideDiff logic below
+            BlockPos prevPos = prev instanceof MultiPart ? ((MultiPart) prev).pos() : pos();
+            RedstonePropagator.addNeighborChange(level(), prevPos, pos());
         }
         propagationMask = 0xF;
     }

--- a/transmission/src/main/java/mrtjp/projectred/transmission/part/FramedRedwirePart.java
+++ b/transmission/src/main/java/mrtjp/projectred/transmission/part/FramedRedwirePart.java
@@ -196,7 +196,7 @@ public abstract class FramedRedwirePart extends BaseCenterWirePart implements IR
     public void propagateOther(int mode) {
         for (int s = 0; s < 6; s++) {
             if (!maskConnects(s)) {
-                RedstonePropagator.addNeighborChange(level(), posOfStraight(s));
+                RedstonePropagator.addNeighborChange(level(), pos(), posOfStraight(s));
             }
         }
     }

--- a/transmission/src/main/java/mrtjp/projectred/transmission/part/RedAlloyWirePart.java
+++ b/transmission/src/main/java/mrtjp/projectred/transmission/part/RedAlloyWirePart.java
@@ -38,14 +38,14 @@ public class RedAlloyWirePart extends RedwirePart {
     public void propagateOther(int mode) {
 
         // Update block above and below
-        RedstonePropagator.addNeighborChange(level(), this.pos().relative(Direction.values()[getSide()]));
-        RedstonePropagator.addNeighborChange(level(), this.pos().relative(Direction.values()[getSide() ^ 1]));
+        RedstonePropagator.addNeighborChange(level(), pos(), pos().relative(Direction.values()[getSide()]));
+        RedstonePropagator.addNeighborChange(level(), pos(), pos().relative(Direction.values()[getSide() ^ 1]));
 
         // Update all 4 rotational sides if they are not connected. They are excluded
         // because things that actually connect are expected to be part of the propagation anyway
         for (int r = 0; r < 4; r++) {
             if (!maskConnects(r)) {
-                RedstonePropagator.addNeighborChange(level(), posOfStraight(r));
+                RedstonePropagator.addNeighborChange(level(), pos(), posOfStraight(r));
             }
         }
 
@@ -53,7 +53,7 @@ public class RedAlloyWirePart extends RedwirePart {
         BlockPos posUnder = this.pos().relative(Direction.values()[getSide()]);
         for (int s = 0; s < 6; s++) {
             if (s != (getSide() ^ 1)) {
-                RedstonePropagator.addNeighborChange(level(), posUnder.relative(Direction.values()[s]));
+                RedstonePropagator.addNeighborChange(level(), posUnder, posUnder.relative(Direction.values()[s]));
             }
         }
     }


### PR DESCRIPTION
* Fix bug causing blocks moved by a frame unable to leave a chunk. Blocks were always being added to the same chunk rather than to the adjacent chunk when crossing boundary (fixes #1815)
* Blocks getting updated by red alloy wires will now receive the correct `fromBlock` position in the neighbor update event (fixes #1472)
* Fix bug in Halo Renderer (part of Project Red Core) which, during non-Fabulous rendering, messes up the PoseStack inside `RenderLevelLastEvent` (pushed but never popped) (fixes #1807, fixes #1799)