### PR TITLE
Fix broken silver ingot smelting recipe and add forge tags for raw metals (1.19)

### DIFF
--- a/exploration/src/main/generated/data/forge/tags/items/raw_materials/silver.json
+++ b/exploration/src/main/generated/data/forge/tags/items/raw_materials/silver.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "projectred_exploration:raw_silver"
+  ]
+}

--- a/exploration/src/main/generated/data/forge/tags/items/raw_materials/tin.json
+++ b/exploration/src/main/generated/data/forge/tags/items/raw_materials/tin.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "projectred_exploration:raw_tin"
+  ]
+}

--- a/exploration/src/main/generated/data/projectred_exploration/recipes/silver_ingot_from_raw_silver_smelting.json
+++ b/exploration/src/main/generated/data/projectred_exploration/recipes/silver_ingot_from_raw_silver_smelting.json
@@ -4,7 +4,7 @@
     "item": "projectred_exploration:silver_ingot"
   },
   "ingredient": {
-    "item": "projectred_exploration:raw_tin"
+    "item": "projectred_exploration:raw_silver"
   },
   "experience": 0.7,
   "cookingtime": 200


### PR DESCRIPTION
Silver ingots were smelted from raw tin, and raw metals were missing their respective forge material tags. This fixes it for 1.19.