### PR TITLE
Bug fixes

### DIFF
--- a/core/src/main/java/mrtjp/projectred/core/BundledSignalsLib.java
+++ b/core/src/main/java/mrtjp/projectred/core/BundledSignalsLib.java
@@ -184,9 +184,9 @@ public class BundledSignalsLib {
         return signal;
     }
 
-    public static int mostSignificantBit(int mask) {
+    public static int mostSignificantBit(short mask) {
         int idx = 0;
-        int m2 = mask >>> 1;
+        int m2 = (mask & 0xFFFF) >>> 1;
         while (m2 != 0) {
             m2 >>>= 1;
             idx++;

--- a/core/src/main/java/mrtjp/projectred/core/CenterLookup.java
+++ b/core/src/main/java/mrtjp/projectred/core/CenterLookup.java
@@ -11,6 +11,8 @@ import net.minecraft.world.level.block.state.BlockState;
 
 import javax.annotation.Nullable;
 
+import static mrtjp.projectred.core.FaceLookup.getBlockEntityForState;
+
 public class CenterLookup {
 
     //Starting conditions
@@ -45,11 +47,8 @@ public class CenterLookup {
         int otherDir = direction ^ 1;
 
         BlockState state = world.getBlockState(pos);
-        BlockEntity tile = world.getBlockEntity(pos);
-        MultiPart part = null;
-        if (tile instanceof TileMultipart) {
-            part = ((TileMultipart) tile).getSlottedPart(direction);
-        }
+        BlockEntity tile = getBlockEntityForState(world, pos, state);
+        MultiPart part = tile instanceof TileMultipart tmp ? tmp.getSlottedPart(direction) : null;
 
         return new CenterLookup(world, pos, direction, state, tile, part, pos, otherDir);
     }
@@ -60,11 +59,8 @@ public class CenterLookup {
         int otherDir = direction ^ 1;
 
         BlockState state = world.getBlockState(otherPos);
-        BlockEntity tile = world.getBlockEntity(otherPos);
-        MultiPart part = null;
-        if (tile instanceof TileMultipart) {
-            part = ((TileMultipart) tile).getSlottedPart(6);
-        }
+        BlockEntity tile = getBlockEntityForState(world, otherPos, state);
+        MultiPart part = tile instanceof TileMultipart tmp ? tmp.getSlottedPart(6) : null;
 
         return new CenterLookup(world, pos, direction, state, tile, part, otherPos, otherDir);
     }

--- a/core/src/main/java/mrtjp/projectred/core/tile/IConnectableTile.java
+++ b/core/src/main/java/mrtjp/projectred/core/tile/IConnectableTile.java
@@ -200,7 +200,6 @@ public interface IConnectableTile extends IBlockEventTile, IConnectable {
         if (p instanceof IConnectable connectable) {
             return canConnectPart(connectable, s, edgeRot) &&
                     outsideCornerEdgeOpen(s, edgeRot) &&
-                    connectable.canConnectCorner(rotFromCorner(s, edgeRot)) && //TODO shouldnt this be handled by next line?
                     connectable.connectCorner(this, rotFromCorner(s, edgeRot), -1);
 
         }

--- a/core/src/main/java/mrtjp/projectred/core/tile/IOrientableBlockEntity.java
+++ b/core/src/main/java/mrtjp/projectred/core/tile/IOrientableBlockEntity.java
@@ -62,9 +62,13 @@ public interface IOrientableBlockEntity extends IBlockEventTile {
 
     default void rotateBlock() {
         setRotation((getRotation() + 1) % 4);
+        onOrientationChange();
     }
 
     default void orientBlock() {
         setSide((getSide() + 1) % 6);
+        onOrientationChange();
     }
+
+    void onOrientationChange();
 }

--- a/expansion/src/main/java/mrtjp/projectred/expansion/tile/BaseFrameMoverTile.java
+++ b/expansion/src/main/java/mrtjp/projectred/expansion/tile/BaseFrameMoverTile.java
@@ -3,6 +3,7 @@ package mrtjp.projectred.expansion.tile;
 import codechicken.multipart.api.RedstoneInteractions;
 import codechicken.multipart.api.tile.RedstoneConnector;
 import mrtjp.projectred.api.Frame;
+import mrtjp.projectred.api.IConnectable;
 import mrtjp.projectred.api.MovementDescriptor;
 import mrtjp.projectred.api.ProjectRedAPI;
 import mrtjp.projectred.core.block.ProjectRedBlock;
@@ -107,6 +108,19 @@ public abstract class BaseFrameMoverTile extends LowLoadPoweredTile implements R
         if (!oldPowered && powered && !isWorking && canConductorWork()) {
             beginMove();
         }
+    }
+
+    @Override
+    public void onOrientationChange() {
+        if (!getLevel().isClientSide) {
+            updateExternals();
+        }
+    }
+
+    @Override
+    public boolean canConnectPart(IConnectable part, int s, int edgeRot) {
+        // Dont allow power wires on front side. Redstone is handled by getConnectionMask
+        return s != getFrontSide() && super.canConnectPart(part, s, edgeRot);
     }
 
     @Override

--- a/fabrication/src/main/java/mrtjp/projectred/fabrication/engine/BaseTile.java
+++ b/fabrication/src/main/java/mrtjp/projectred/fabrication/engine/BaseTile.java
@@ -106,7 +106,6 @@ public abstract class BaseTile implements FETile {
     public void buildInteractionZoneList(List<InteractionZone> zones) {
     }
 
-    @OnlyIn(Dist.CLIENT)
     public void buildToolTip(List<Component> toolTip) {
         toolTip.add(Component.translatable(tileType.getUnlocalizedName()));
     }

--- a/fabrication/src/main/java/mrtjp/projectred/fabrication/engine/gates/SimpleGateTile.java
+++ b/fabrication/src/main/java/mrtjp/projectred/fabrication/engine/gates/SimpleGateTile.java
@@ -9,8 +9,6 @@ import mrtjp.projectred.fabrication.editor.ICWorkbenchEditor;
 import mrtjp.projectred.fabrication.editor.tools.InteractionZone;
 import mrtjp.projectred.fabrication.editor.tools.SimpleInteractionZone;
 import net.minecraft.network.chat.Component;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -53,7 +51,6 @@ public abstract class SimpleGateTile extends SidedRedstoneGateTile {
         addDeadSidesInteractions(zones, interactMask(), this::getBoundsForIOToggleZone, this::toggleDeadSide, this::getDeadSideToolTip);
     }
 
-    @OnlyIn(Dist.CLIENT)
     protected Component getDeadSideToolTip(int r) {
         boolean isEnabled = (getShape() & rotationToDeadSideBit(r)) == 0;
         return Component.translatable(isEnabled ? UL_SIDE_ENABLED : UL_SIDE_DISABLED).withStyle(ICWorkbenchEditor.UNIFORM_GRAY);

--- a/fabrication/src/main/java/mrtjp/projectred/fabrication/part/FabricatedGatePart.java
+++ b/fabrication/src/main/java/mrtjp/projectred/fabrication/part/FabricatedGatePart.java
@@ -66,6 +66,7 @@ public class FabricatedGatePart extends BundledGatePart {
     @Override
     public void save(CompoundTag tag) {
         super.save(tag);
+        tag.put("item_stack", itemStackTag);
         tag.putString("ic_name", icName);
         tag.putLong("sim_time", level().getGameTime() - simulationTimeStart);
         tag.putInt("compile_format", compileFormat);
@@ -76,6 +77,7 @@ public class FabricatedGatePart extends BundledGatePart {
     @Override
     public void load(CompoundTag tag) {
         super.load(tag);
+        itemStackTag = tag.getCompound("item_stack");
         icName = tag.getString("ic_name");
         simulationTimeStart = tag.getLong("sim_time");
         compileFormat = tag.getInt("compile_format");

--- a/integration/src/main/java/mrtjp/projectred/integration/part/BundledGatePart.java
+++ b/integration/src/main/java/mrtjp/projectred/integration/part/BundledGatePart.java
@@ -24,7 +24,6 @@ import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.VoxelShape;
 
@@ -96,18 +95,18 @@ public abstract class BundledGatePart extends RedstoneGatePart implements IBundl
     //region Connections
     @Override
     public boolean discoverStraightOverride(int absDir) {
-        BlockPos pos = pos().relative(Direction.values()[absDir]);
-        BlockEntity tile = level().getBlockEntity(pos);
-        if (tile instanceof IMaskedBundledTile b) {
+        FaceLookup lookup = FaceLookup.lookupStraight(level(), pos(), getSide(), Rotation.rotationTo(getSide(), absDir));
+
+        if (lookup.tile instanceof IMaskedBundledTile b) {
             int r = Rotation.rotationTo(absDir, getSide());
             return b.canConnectBundled(absDir ^ 1) && (b.getConnectionMask(absDir ^ 1) & 1 << r) != 0;
         }
 
-        if (tile instanceof IBundledTile) {
-            return ((IBundledTile) tile).canConnectBundled(absDir ^ 1);
+        if (lookup.tile instanceof IBundledTile b) {
+            return b.canConnectBundled(absDir ^ 1);
         }
 
-        if (BundledSignalsLib.canConnectBundledViaInteraction(level(), pos, Direction.values()[absDir ^ 1])) {
+        if (BundledSignalsLib.canConnectBundledViaInteraction(level(), lookup.otherPos, Direction.values()[absDir ^ 1])) { //TODO add otherDir to lookup
             return true;
         }
 

--- a/transmission/src/main/java/mrtjp/projectred/transmission/part/BundledCablePart.java
+++ b/transmission/src/main/java/mrtjp/projectred/transmission/part/BundledCablePart.java
@@ -14,7 +14,6 @@ import mrtjp.projectred.transmission.WireType;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.world.level.block.entity.BlockEntity;
 
 import javax.annotation.Nullable;
 import java.util.Arrays;
@@ -131,18 +130,18 @@ public class BundledCablePart extends BaseFaceWirePart implements IBundledCableP
 
     @Override
     public boolean discoverStraightOverride(int absDir) {
-        BlockPos pos = pos().relative(Direction.values()[absDir]);
-        BlockEntity tile = level().getBlockEntity(pos);
-        if (tile instanceof IMaskedBundledTile b) {
+        FaceLookup lookup = FaceLookup.lookupStraight(level(), pos(), getSide(), Rotation.rotationTo(getSide(), absDir));
+
+        if (lookup.tile instanceof IMaskedBundledTile b) {
             int r = Rotation.rotationTo(absDir, getSide());
             return b.canConnectBundled(absDir^1) && (b.getConnectionMask(absDir^1) & 1<< r) != 0;
         }
 
-        if (tile instanceof IBundledTile) {
-            return ((IBundledTile) tile).canConnectBundled(absDir^1);
+        if (lookup.tile instanceof IBundledTile b) {
+            return b.canConnectBundled(absDir^1);
         }
 
-        return BundledSignalsLib.canConnectBundledViaInteraction(level(), pos, Direction.values()[absDir^1]);
+        return BundledSignalsLib.canConnectBundledViaInteraction(level(), lookup.otherPos, Direction.values()[absDir^1]); // TODO add otherDir to lookup
     }
     //endregion
 

--- a/transmission/src/main/java/mrtjp/projectred/transmission/part/FramedBundledCablePart.java
+++ b/transmission/src/main/java/mrtjp/projectred/transmission/part/FramedBundledCablePart.java
@@ -13,7 +13,6 @@ import mrtjp.projectred.transmission.WireType;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.world.level.block.entity.BlockEntity;
 
 import javax.annotation.Nullable;
 import java.util.Arrays;
@@ -127,17 +126,17 @@ public class FramedBundledCablePart extends BaseCenterWirePart implements IBundl
 
     @Override
     public boolean discoverStraightOverride(int absDir) {
-        BlockPos pos = pos().relative(Direction.values()[absDir]);
-        BlockEntity tile = level().getBlockEntity(pos);
-        if (tile instanceof IMaskedBundledTile b) {
+        CenterLookup lookup = CenterLookup.lookupStraightCenter(level(), pos(), absDir);
+
+        if (lookup.tile instanceof IMaskedBundledTile b) {
             return b.canConnectBundled(absDir^1) && (b.getConnectionMask(absDir^1) & 0x10) != 0;
         }
 
-        if (tile instanceof IBundledTile) {
-            return ((IBundledTile) tile).canConnectBundled(absDir^1);
+        if (lookup.tile instanceof IBundledTile b) {
+            return b.canConnectBundled(absDir^1);
         }
 
-        return BundledSignalsLib.canConnectBundledViaInteraction(level(), pos, Direction.values()[absDir^1]);
+        return BundledSignalsLib.canConnectBundledViaInteraction(level(), lookup.otherPos, Direction.values()[absDir^1]); //TODO add otherDir to lookup
     }
     //endregion
 


### PR DESCRIPTION
* Fixed integer conversion issue causing black signal (bit 15) being converted wrong by bus converter in digital to analog mode
* Fixed issue where wires were re-connecting to a tile during removal when that tile performed its neighbor update (i.e. after block state removal, but before tile was delete from world).
* Fixed Fabricated Gate pick-block not working after world reload due to original item NBT not being saved
* Fixed wires connecting to front-side of Motors and Actuators
* Fixed IC tile interactions not working in multiplayer due to method incorrectly marked as client-only (fixes #1853)