### PR TITLE
Bug fixes

### DIFF
--- a/core/src/main/java/mrtjp/projectred/core/FaceLookup.java
+++ b/core/src/main/java/mrtjp/projectred/core/FaceLookup.java
@@ -19,6 +19,7 @@ public class FaceLookup {
     public final BlockPos pos;
     public final int side;
     public final int r;
+    public final int dir;
 
     //Located objects
     public final BlockState state;
@@ -30,12 +31,14 @@ public class FaceLookup {
     public final BlockPos otherPos;
     public final int otherSide;
     public final int otherRotation;
+    public final int otherDir;
 
     public FaceLookup(Level world, BlockPos pos, int side, int r, BlockState state, @Nullable BlockEntity tile, @Nullable MultiPart part, BlockPos otherPos, int otherSide, int otherRotation) {
         this.world = world;
         this.pos = pos;
         this.side = side;
         this.r = r;
+        this.dir = r == -1 ? side ^ 1 : Rotation.rotateSide(side, r);
         this.state = state;
         this.block = state.getBlock();
         this.tile = tile;
@@ -43,6 +46,8 @@ public class FaceLookup {
         this.otherPos = otherPos;
         this.otherSide = otherSide;
         this.otherRotation = otherRotation;
+        // When otherSide == -1, otherRotation is already otherDir
+        this.otherDir = otherSide == -1 ? otherRotation : Rotation.rotateSide(otherSide, otherRotation);
     }
 
     public static FaceLookup lookupCorner(Level world, BlockPos pos, int side, int r) {
@@ -87,14 +92,14 @@ public class FaceLookup {
     }
 
     public static FaceLookup lookupInsideCenter(Level world, BlockPos pos, int side) {
-        int otherSide = side;
-        int otherRotation = -1; // Part is not on face
+        int otherSide = -1; // Center part not on side
+        int otherRotation = side; // For this case, rotation is used as direction
 
         BlockState state = world.getBlockState(pos);
         BlockEntity tile = getBlockEntityForState(world, pos, state);
         MultiPart part = tile instanceof TileMultipart tmp ? tmp.getSlottedPart(6) : null;
 
-        return new FaceLookup(world, pos, side, -1, state, tile, part, pos, otherRotation, otherSide);
+        return new FaceLookup(world, pos, side, -1, state, tile, part, pos, otherSide, otherRotation);
     }
 
     /**

--- a/core/src/main/java/mrtjp/projectred/core/RedstoneCenterLookup.java
+++ b/core/src/main/java/mrtjp/projectred/core/RedstoneCenterLookup.java
@@ -1,0 +1,35 @@
+package mrtjp.projectred.core;
+
+import codechicken.multipart.api.RedstoneInteractions;
+import codechicken.multipart.api.part.MultiPart;
+import codechicken.multipart.api.part.redstone.RedstonePart;
+import mrtjp.projectred.core.part.IRedwireEmitter;
+import mrtjp.projectred.core.part.IRedwirePart;
+
+public class RedstoneCenterLookup {
+
+    public static int resolveSignal(CenterLookup lookup, boolean diminishRedwire) {
+        if (lookup.part instanceof IRedwirePart rw) {
+
+            int signal = rw.getRedwireSignal(lookup.otherDirection);
+            if (diminishRedwire && rw.diminishOnSide(lookup.otherDirection)) {
+                signal--;
+            }
+            return Math.max(0, signal);
+        }
+
+        if (lookup.part instanceof IRedwireEmitter rwe) {
+            return rwe.getRedwireSignal(lookup.otherDirection);
+        }
+
+        if (lookup.part instanceof RedstonePart rw) {
+            return Math.max(rw.strongPowerLevel(lookup.otherDirection), rw.weakPowerLevel(lookup.otherDirection));
+        }
+
+        return 0;
+    }
+
+    public static int resolveVanillaSignal(CenterLookup lookup, MultiPart part) {
+        return RedstoneInteractions.getPowerTo(part, lookup.direction) * 17;
+    }
+}

--- a/core/src/main/java/mrtjp/projectred/core/RedstoneFaceLookup.java
+++ b/core/src/main/java/mrtjp/projectred/core/RedstoneFaceLookup.java
@@ -1,0 +1,65 @@
+package mrtjp.projectred.core;
+
+import codechicken.multipart.api.RedstoneInteractions;
+import codechicken.multipart.api.part.MultiPart;
+import codechicken.multipart.api.part.redstone.FaceRedstonePart;
+import mrtjp.projectred.core.part.IRedwireEmitter;
+import mrtjp.projectred.core.part.IRedwirePart;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.RedStoneWireBlock;
+
+public class RedstoneFaceLookup {
+
+    public static int resolveSignal(FaceLookup lookup, boolean diminishRedwire) {
+
+        if (lookup.part instanceof IRedwirePart rp) {
+            int signal = rp.getRedwireSignal(lookup.otherRotation);
+            if (diminishRedwire && rp.diminishOnSide(lookup.otherRotation)) {
+                signal--;
+            }
+            return Math.max(0, signal);
+        }
+
+        if (lookup.part instanceof IRedwireEmitter rwe) {
+            return rwe.getRedwireSignal(lookup.otherRotation);
+        }
+
+        if (lookup.part instanceof FaceRedstonePart fp) {
+            int s = lookup.otherDir;
+            return Math.max(fp.strongPowerLevel(s), fp.weakPowerLevel(s)) * 17;
+        }
+
+        return 0;
+    }
+
+    public static int resolveVanillaSignal(FaceLookup lookup, MultiPart part, boolean strong, boolean limitDust) {
+        int signal;
+
+        // Dust signal
+        if (lookup.block == Blocks.REDSTONE_WIRE) {
+            signal = Math.max(lookup.state.getValue(RedStoneWireBlock.POWER) - 1, 0);
+            if (limitDust) {
+                return signal;
+            }
+        }
+
+        // Strong signal
+        return RedstoneInteractions.getPowerTo(part, lookup.dir) * 17;
+
+        // TODO Investigate below. I think RedstoneInteractions already takes care of strong/weak check,
+        //      as it is part of Level#getSignal now.
+//        // Strong signal
+//        signal = RedstoneInteractions.getPowerTo(part, lookup.dir) * 17;
+//        if (signal > 0 || strong) {
+//            return signal;
+//        }
+//
+//        // Weak signal
+//        if (lookup.state.isRedstoneConductor(lookup.world, lookup.otherPos)) {
+//            signal = lookup.world.getBestNeighborSignal(lookup.otherPos) * 17;
+//        }
+//
+//        return signal;
+    }
+
+}

--- a/fabrication/src/main/generated/.cache/023a1c9b0a2cb237e03abf252e44e562954ebd68
+++ b/fabrication/src/main/generated/.cache/023a1c9b0a2cb237e03abf252e44e562954ebd68
@@ -1,0 +1,3 @@
+// 1.19.2	2024-05-13T08:16:56.214014	ProjectRed-Fabrication Block Tags
+44a36d21accd9b32360c42fd97ae81903501584c data/minecraft/tags/blocks/mineable/pickaxe.json
+44a36d21accd9b32360c42fd97ae81903501584c data/minecraft/tags/blocks/needs_stone_tool.json

--- a/fabrication/src/main/generated/.cache/cc933257d7c8d29d64dce4638a1d4f85a5ad3b65
+++ b/fabrication/src/main/generated/.cache/cc933257d7c8d29d64dce4638a1d4f85a5ad3b65
@@ -1,0 +1,5 @@
+// 1.19.2	2024-05-13T08:21:16.055865	ProjectRed-Fabrication Block Loot Tables
+170a77041b752756521029fe2d36dc0952fa584e data/projectred_fabrication/loot_tables/blocks/ic_workbench.json
+22bcef3df841e4276c942f4cdfdbe2147bb0a0b7 data/projectred_fabrication/loot_tables/blocks/lithography_table.json
+473b02f14e0d6f9558ac074a2a85bccc87f39902 data/projectred_fabrication/loot_tables/blocks/packaging_table.json
+8a9d97721b3b18c0ff75aa203c9c033290e1f3dd data/projectred_fabrication/loot_tables/blocks/plotting_table.json

--- a/fabrication/src/main/generated/data/minecraft/tags/blocks/mineable/pickaxe.json
+++ b/fabrication/src/main/generated/data/minecraft/tags/blocks/mineable/pickaxe.json
@@ -1,0 +1,8 @@
+{
+  "values": [
+    "projectred_fabrication:ic_workbench",
+    "projectred_fabrication:plotting_table",
+    "projectred_fabrication:lithography_table",
+    "projectred_fabrication:packaging_table"
+  ]
+}

--- a/fabrication/src/main/generated/data/minecraft/tags/blocks/needs_stone_tool.json
+++ b/fabrication/src/main/generated/data/minecraft/tags/blocks/needs_stone_tool.json
@@ -1,0 +1,8 @@
+{
+  "values": [
+    "projectred_fabrication:ic_workbench",
+    "projectred_fabrication:plotting_table",
+    "projectred_fabrication:lithography_table",
+    "projectred_fabrication:packaging_table"
+  ]
+}

--- a/fabrication/src/main/generated/data/projectred_fabrication/loot_tables/blocks/ic_workbench.json
+++ b/fabrication/src/main/generated/data/projectred_fabrication/loot_tables/blocks/ic_workbench.json
@@ -1,0 +1,15 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "projectred_fabrication:ic_workbench"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/fabrication/src/main/generated/data/projectred_fabrication/loot_tables/blocks/lithography_table.json
+++ b/fabrication/src/main/generated/data/projectred_fabrication/loot_tables/blocks/lithography_table.json
@@ -1,0 +1,15 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "projectred_fabrication:lithography_table"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/fabrication/src/main/generated/data/projectred_fabrication/loot_tables/blocks/packaging_table.json
+++ b/fabrication/src/main/generated/data/projectred_fabrication/loot_tables/blocks/packaging_table.json
@@ -1,0 +1,15 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "projectred_fabrication:packaging_table"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/fabrication/src/main/generated/data/projectred_fabrication/loot_tables/blocks/plotting_table.json
+++ b/fabrication/src/main/generated/data/projectred_fabrication/loot_tables/blocks/plotting_table.json
@@ -1,0 +1,15 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "projectred_fabrication:plotting_table"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/fabrication/src/main/java/mrtjp/projectred/fabrication/ProjectRedFabrication.java
+++ b/fabrication/src/main/java/mrtjp/projectred/fabrication/ProjectRedFabrication.java
@@ -2,10 +2,7 @@ package mrtjp.projectred.fabrication;
 
 import codechicken.lib.gui.SimpleCreativeTab;
 import codechicken.multipart.api.MultipartType;
-import mrtjp.projectred.fabrication.data.FabricationBlockStateModelProvider;
-import mrtjp.projectred.fabrication.data.FabricationItemModelProvider;
-import mrtjp.projectred.fabrication.data.FabricationLanguageProvider;
-import mrtjp.projectred.fabrication.data.FabricationRecipeProvider;
+import mrtjp.projectred.fabrication.data.*;
 import mrtjp.projectred.fabrication.init.*;
 import net.minecraft.data.DataGenerator;
 import net.minecraft.world.inventory.MenuType;
@@ -77,6 +74,8 @@ public class ProjectRedFabrication {
         generator.addProvider(event.includeClient(), new FabricationItemModelProvider(generator, fileHelper));
         generator.addProvider(event.includeClient(), new FabricationLanguageProvider(generator));
 
+        generator.addProvider(event.includeServer(), new FabricationBlockTagsProvider(generator, fileHelper));
         generator.addProvider(event.includeServer(), new FabricationRecipeProvider(generator));
+        generator.addProvider(event.includeServer(), new FabricationLootTableProvider(generator));
     }
 }

--- a/fabrication/src/main/java/mrtjp/projectred/fabrication/data/FabricationBlockTagsProvider.java
+++ b/fabrication/src/main/java/mrtjp/projectred/fabrication/data/FabricationBlockTagsProvider.java
@@ -1,0 +1,38 @@
+package mrtjp.projectred.fabrication.data;
+
+import net.minecraft.data.DataGenerator;
+import net.minecraft.data.tags.BlockTagsProvider;
+import net.minecraft.tags.BlockTags;
+import net.minecraftforge.common.data.ExistingFileHelper;
+import org.jetbrains.annotations.Nullable;
+
+import static mrtjp.projectred.fabrication.ProjectRedFabrication.MOD_ID;
+import static mrtjp.projectred.fabrication.init.FabricationBlocks.*;
+
+public class FabricationBlockTagsProvider extends BlockTagsProvider {
+
+    public FabricationBlockTagsProvider(DataGenerator gen, @Nullable ExistingFileHelper existingFileHelper) {
+        super(gen, MOD_ID, existingFileHelper);
+    }
+
+    @Override
+    public String getName() {
+        return "ProjectRed-Fabrication Block Tags";
+    }
+
+    @Override
+    protected void addTags() {
+
+        tag(BlockTags.MINEABLE_WITH_PICKAXE)
+                .add(IC_WORKBENCH_BLOCK.get())
+                .add(PLOTTING_TABLE_BLOCK.get())
+                .add(LITHOGRAPHY_TABLE_BLOCK.get())
+                .add(PACKAGING_TABLE_BLOCK.get());
+
+        tag(BlockTags.NEEDS_STONE_TOOL)
+                .add(IC_WORKBENCH_BLOCK.get())
+                .add(PLOTTING_TABLE_BLOCK.get())
+                .add(LITHOGRAPHY_TABLE_BLOCK.get())
+                .add(PACKAGING_TABLE_BLOCK.get());
+    }
+}

--- a/fabrication/src/main/java/mrtjp/projectred/fabrication/data/FabricationLootTableProvider.java
+++ b/fabrication/src/main/java/mrtjp/projectred/fabrication/data/FabricationLootTableProvider.java
@@ -1,0 +1,26 @@
+package mrtjp.projectred.fabrication.data;
+
+import codechicken.lib.datagen.LootTableProvider;
+import net.minecraft.data.DataGenerator;
+
+import static mrtjp.projectred.fabrication.init.FabricationBlocks.*;
+
+public class FabricationLootTableProvider extends LootTableProvider.BlockLootProvider {
+
+    public FabricationLootTableProvider(DataGenerator dataGenerator) {
+        super(dataGenerator);
+    }
+
+    @Override
+    public String getName() {
+        return "ProjectRed-Fabrication Block Loot Tables";
+    }
+
+    @Override
+    protected void registerTables() {
+        register(IC_WORKBENCH_BLOCK.get(), singleItem(IC_WORKBENCH_BLOCK.get()));
+        register(PLOTTING_TABLE_BLOCK.get(), singleItem(PLOTTING_TABLE_BLOCK.get()));
+        register(LITHOGRAPHY_TABLE_BLOCK.get(), singleItem(LITHOGRAPHY_TABLE_BLOCK.get()));
+        register(PACKAGING_TABLE_BLOCK.get(), singleItem(PACKAGING_TABLE_BLOCK.get()));
+    }
+}

--- a/integration/src/main/java/mrtjp/projectred/integration/part/ArrayGatePart.java
+++ b/integration/src/main/java/mrtjp/projectred/integration/part/ArrayGatePart.java
@@ -182,33 +182,6 @@ public abstract class ArrayGatePart extends RedstoneGatePart implements IRedwire
         return super.resolveSignal(lookup);
     }
 
-    protected int getVanillaSignal(int r, boolean strong, boolean limitDust) {
-        FaceLookup lookup = FaceLookup.lookupStraight(level(), pos(), getSide(), r);
-        int signal = 0;
-
-        // Dust signal
-        if (lookup.block == Blocks.REDSTONE_WIRE) {
-            signal = Math.max(lookup.state.getValue(RedStoneWireBlock.POWER) - 1, 0);
-            if (limitDust) {
-                return signal;
-            }
-        }
-
-        // Strong signal
-        int dir = absoluteDir(r);
-        signal = RedstoneInteractions.getPowerTo(this, dir) * 17;
-        if (signal > 0 && strong) {
-            return signal;
-        }
-
-        // Weak signal
-        if (lookup.state.isRedstoneConductor(level(), lookup.otherPos)) {
-            signal = level().getBestNeighborSignal(lookup.otherPos) * 17;
-        }
-
-        return signal;
-    }
-
     @Override
     public void onSignalUpdate() {
         tile().setChanged();

--- a/integration/src/main/java/mrtjp/projectred/integration/part/GatePart.java
+++ b/integration/src/main/java/mrtjp/projectred/integration/part/GatePart.java
@@ -19,6 +19,7 @@ import mrtjp.projectred.api.IScrewdriver;
 import mrtjp.projectred.core.Configurator;
 import mrtjp.projectred.core.PlacementLib;
 import mrtjp.projectred.core.part.IConnectableFacePart;
+import mrtjp.projectred.core.part.IOrientableFacePart;
 import mrtjp.projectred.integration.GateType;
 import mrtjp.projectred.integration.client.GateComponentModels;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
@@ -43,7 +44,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Consumer;
 
-public abstract class GatePart extends BaseMultipart implements IConnectableFacePart, TickablePart, FacePart, NormalOcclusionPart, IconHitEffectsPart, IGateRenderData {
+public abstract class GatePart extends BaseMultipart implements IConnectableFacePart, IOrientableFacePart, TickablePart, FacePart, NormalOcclusionPart, IconHitEffectsPart, IGateRenderData {
 
     private static final int KEY_UPDATE = 0;
     private static final int KEY_ORIENTATION = 1;

--- a/transmission/src/main/java/mrtjp/projectred/transmission/part/BaseFaceWirePart.java
+++ b/transmission/src/main/java/mrtjp/projectred/transmission/part/BaseFaceWirePart.java
@@ -73,21 +73,6 @@ public abstract class BaseFaceWirePart extends BaseWirePart implements IConnecta
     public int getSide() {
         return side & 0xFF;
     }
-
-    @Override
-    public void setSide(int s) {
-        throw new RuntimeException("Attempted to orient a wire!");
-    }
-
-    @Override
-    public int getRotation() {
-        return 0; // Wires don't rotate
-    }
-
-    @Override
-    public void setRotation(int r) {
-        throw new RuntimeException("Attempted to rotate a wire!");
-    }
     //endregion
 
     @Override
@@ -260,11 +245,11 @@ public abstract class BaseFaceWirePart extends BaseWirePart implements IConnecta
     @Override
     public boolean discoverOpen(int r) {
         // Condition 1: Edge must be empty (this is where strips go)
-        MultiPart edgePart = tile().getSlottedPart(PartMap.edgeBetween(getSide(), absoluteDir(r)));
+        MultiPart edgePart = tile().getSlottedPart(PartMap.edgeBetween(getSide(), IConnectableFacePart.absoluteDir(this, r)));
         if (edgePart != null) return false;
 
         // Condition 2: Part on inside face must not consume the connection
-        MultiPart insidePart = tile().getSlottedPart(absoluteDir(r));
+        MultiPart insidePart = tile().getSlottedPart(IConnectableFacePart.absoluteDir(this, r));
         if (insidePart instanceof IConnectable) {
             //TODO this seems sus. Why let part connect inside AND outside?
             return canConnectPart((IConnectable) insidePart, r);

--- a/transmission/src/main/java/mrtjp/projectred/transmission/part/FacePowerWire.java
+++ b/transmission/src/main/java/mrtjp/projectred/transmission/part/FacePowerWire.java
@@ -3,6 +3,7 @@ package mrtjp.projectred.transmission.part;
 import codechicken.lib.vec.Rotation;
 import mrtjp.projectred.api.IConnectable;
 import mrtjp.projectred.core.FaceLookup;
+import mrtjp.projectred.core.part.IConnectableFacePart;
 import mrtjp.projectred.core.power.IPowerConductorSource;
 import mrtjp.projectred.core.power.IPowerConnectable;
 import mrtjp.projectred.core.power.PowerConductor;
@@ -90,7 +91,7 @@ public abstract class FacePowerWire extends BaseFaceWirePart implements IPowerCo
     //region Connections
     @Override
     public boolean discoverCornerOverride(int absDir) {
-        int r = absoluteRot(absDir);
+        int r = IConnectableFacePart.absoluteRot(this, absDir);
         FaceLookup lookup = FaceLookup.lookupCorner(level(), pos(), getSide(), r);
         if (lookup.tile instanceof IConnectable) {
             return ((IConnectable) lookup.tile).connectCorner(this, getSide() ^ 1, Rotation.rotationTo(getSide(), absDir ^ 1));
@@ -100,7 +101,7 @@ public abstract class FacePowerWire extends BaseFaceWirePart implements IPowerCo
 
     @Override
     public boolean discoverStraightOverride(int absDir) {
-        int r = absoluteRot(absDir);
+        int r = IConnectableFacePart.absoluteRot(this, absDir);
         FaceLookup lookup = FaceLookup.lookupStraight(level(), pos(), getSide(), r);
         if (lookup.tile instanceof IConnectable) {
             return ((IConnectable) lookup.tile).connectStraight(this, absDir ^ 1, Rotation.rotationTo(absDir, getSide()));

--- a/transmission/src/main/java/mrtjp/projectred/transmission/part/InsulatedRedAlloyWirePart.java
+++ b/transmission/src/main/java/mrtjp/projectred/transmission/part/InsulatedRedAlloyWirePart.java
@@ -1,7 +1,9 @@
 package mrtjp.projectred.transmission.part;
 
+import codechicken.lib.vec.Rotation;
 import mrtjp.projectred.api.IConnectable;
 import mrtjp.projectred.core.FaceLookup;
+import mrtjp.projectred.core.part.IConnectableFacePart;
 import mrtjp.projectred.transmission.WireType;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 
@@ -56,7 +58,7 @@ public class InsulatedRedAlloyWirePart extends RedwirePart implements IInsulated
             return 0;
 
         // Can't power unconnected sides (unlike uninsulated)
-        int r = absoluteRot(side);
+        int r = IConnectableFacePart.absoluteRot(this, side);
         if (!maskConnects(r))
             return 0;
 

--- a/transmission/src/main/java/mrtjp/projectred/transmission/part/RedwirePart.java
+++ b/transmission/src/main/java/mrtjp/projectred/transmission/part/RedwirePart.java
@@ -12,10 +12,7 @@ import mrtjp.projectred.api.IConnectable;
 import mrtjp.projectred.core.Configurator;
 import mrtjp.projectred.core.FaceLookup;
 import mrtjp.projectred.core.RedstonePropagator;
-import mrtjp.projectred.core.part.IPropagationFacePart;
-import mrtjp.projectred.core.part.IRedstonePropagationPart;
-import mrtjp.projectred.core.part.IRedwireEmitter;
-import mrtjp.projectred.core.part.IRedwirePart;
+import mrtjp.projectred.core.part.*;
 import mrtjp.projectred.transmission.WireType;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -124,7 +121,7 @@ public abstract class RedwirePart extends BaseFaceWirePart implements IRedstoneP
     public int weakPowerLevel(int side) {
         // If side is towards a rotation
         if ((side & 6) != (getSide() & 6)) {
-            int r = absoluteRot(side);
+            int r = Rotation.rotationTo(getSide(), side);
             if (maskConnectsInside(r))
                 return 0;
         }
@@ -145,7 +142,7 @@ public abstract class RedwirePart extends BaseFaceWirePart implements IRedstoneP
     //region IConnectable overrides
     @Override
     public boolean discoverOpen(int r) {
-        int absDir = absoluteDir(r);
+        int absDir = IConnectableFacePart.absoluteDir(this, r);
         RedstoneTile tile = (RedstoneTile) this.tile(); // IRedstoneTile is mixed in
         return (tile.openConnections(absDir) & 1 << Rotation.rotationTo(absDir & 6, getSide())) != 0;
     }
@@ -162,7 +159,7 @@ public abstract class RedwirePart extends BaseFaceWirePart implements IRedstoneP
 
     @Override
     public boolean discoverInternalOverride(int r) {
-        MultiPart part = tile().getSlottedPart(absoluteDir(r));
+        MultiPart part = tile().getSlottedPart(IConnectableFacePart.absoluteDir(this, r));
         if (part instanceof FaceRedstonePart) {
             return ((FaceRedstonePart) part).canConnectRedstone(getSide());
         }
@@ -298,7 +295,7 @@ public abstract class RedwirePart extends BaseFaceWirePart implements IRedstoneP
         }
 
         // Strong signal
-        int dir = absoluteDir(r);
+        int dir = IConnectableFacePart.absoluteDir(this, r);
         signal = RedstoneInteractions.getPowerTo(this, dir) * 17;
         if (signal > 0 || strong) {
             return signal;


### PR DESCRIPTION
* Fix missing drops and mining levels on Fabrication blocks
* Fix Array gates sourcing redwire strength using weak signals to adjacent block (essentially double-weak signals to gate)
* Internal cleanup
   *  Separate `IOrientableFacePart` from `IConnectableFacePart`. This prevents non-rotatable face parts like wires from being forced to adopt that interface
   * Reduced some duplicate code by moving redstone signal resolution logic to static libs