### PR TITLE
Bug fixes for 1.20

### DIFF
--- a/core/src/main/java/mrtjp/projectred/core/client/HaloRenderer.java
+++ b/core/src/main/java/mrtjp/projectred/core/client/HaloRenderer.java
@@ -86,6 +86,9 @@ public class HaloRenderer {
     private static final LinkedList<HaloRenderData> entityHalos = new LinkedList<>();
     // Global offset for moving block entities
     private static final Vector3 offset = Vector3.ZERO.copy();
+    // Used for Forge bug workaround. See onRenderLevelStageEvent
+    // TODO remove when porting to > 1.20.1
+    private static @Nullable PoseStack capturedPoseStack = null;
 
     //region Init and event handlers
     public static void init() {
@@ -108,7 +111,20 @@ public class HaloRenderer {
     public static void onRenderLevelStageEvent(final RenderLevelStageEvent event) {
         if (event.getStage().equals(AFTER_PARTICLES)) {
             onRenderStageAfterParticles(event);
+            capturedPoseStack = event.getPoseStack();
         } else if (event.getStage().equals(AFTER_LEVEL)) {
+            // Workaround for non-backported Forge bug where the AFTER_LEVEL call gets the wrong PoseStack. We will retain the valid
+            // PoseStack from the AFTER_PARTICLE call and reuse it here.
+            // https://github.com/neoforged/NeoForge/pull/231
+            // https://github.com/MrTJP/ProjectRed/issues/1868
+            // TODO remove when porting to > 1.20.1
+            if (capturedPoseStack != null) {
+                var e2 = new RenderLevelStageEvent(event.getStage(), event.getLevelRenderer(), capturedPoseStack, event.getProjectionMatrix(), event.getRenderTick(), event.getPartialTick(), event.getCamera(), event.getFrustum());
+                capturedPoseStack = null;
+                onRenderStageAfterLevel(e2);
+                return;
+            }
+
             onRenderStageAfterLevel(event);
         }
     }
@@ -217,7 +233,7 @@ public class HaloRenderer {
             List<HaloRenderData> lightList = pollHalos(levelHalos);
 
             // Prepare render
-            Vec3 cam = Minecraft.getInstance().getEntityRenderDispatcher().camera.getPosition();
+            Vec3 cam = event.getCamera().getPosition();
             PoseStack stack = event.getPoseStack();
             stack.pushPose();
             stack.translate(-cam.x, -cam.y, -cam.z);

--- a/expansion/src/main/java/mrtjp/projectred/expansion/tile/AutoCrafterTile.java
+++ b/expansion/src/main/java/mrtjp/projectred/expansion/tile/AutoCrafterTile.java
@@ -9,6 +9,7 @@ import mrtjp.projectred.expansion.init.ExpansionBlocks;
 import mrtjp.projectred.expansion.inventory.container.AutoCrafterContainer;
 import mrtjp.projectred.expansion.item.RecipePlanItem;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.Container;
@@ -19,6 +20,14 @@ import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.ForgeCapabilities;
+import net.minecraftforge.common.util.LazyOptional;
+import net.minecraftforge.items.IItemHandler;
+import net.minecraftforge.items.wrapper.InvWrapper;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 public class AutoCrafterTile extends BaseMachineTile implements CraftingHelper.InventorySource {
 
@@ -32,6 +41,8 @@ public class AutoCrafterTile extends BaseMachineTile implements CraftingHelper.I
     };
     private final BaseInventory storageInventory = new BaseInventory(18);
     private final BaseInventory craftingGrid = new BaseInventory(9);
+
+    private final LazyOptional<? extends IItemHandler> handler = LazyOptional.of(() -> new InvWrapper(storageInventory));
 
     private final CraftingHelper craftingHelper = new CraftingHelper(this);
 
@@ -217,6 +228,23 @@ public class AutoCrafterTile extends BaseMachineTile implements CraftingHelper.I
         updateRecipeIfNeeded();
         craftingHelper.onCraftedIntoStorage();
         cyclePlan();
+    }
+    //endregion
+
+    //region Capabilities
+    @Nonnull
+    @Override
+    public <T> LazyOptional<T> getCapability(@Nonnull Capability<T> cap, @Nullable Direction side) {
+        if (!this.remove && cap == ForgeCapabilities.ITEM_HANDLER) {
+            return handler.cast();
+        }
+        return super.getCapability(cap, side);
+    }
+
+    @Override
+    public void invalidateCaps() {
+        super.invalidateCaps();
+        handler.invalidate();
     }
     //endregion
 }

--- a/illumination/src/main/java/mrtjp/projectred/illumination/MultipartLightProperties.java
+++ b/illumination/src/main/java/mrtjp/projectred/illumination/MultipartLightProperties.java
@@ -47,6 +47,7 @@ public abstract class MultipartLightProperties {
     public abstract ItemStack makeStack(int color, boolean inverted);
 
     public abstract VoxelShape getShape(int side);
+    public abstract Cuboid6 getBounds(int side);
     public abstract Cuboid6 getGlowBounds(int side);
     //endregion
 

--- a/illumination/src/main/java/mrtjp/projectred/illumination/part/CageLightProperties.java
+++ b/illumination/src/main/java/mrtjp/projectred/illumination/part/CageLightProperties.java
@@ -33,6 +33,11 @@ public class CageLightProperties extends MultipartLightProperties {
     }
 
     @Override
+    public Cuboid6 getBounds(int side) {
+        return BOUNDS[side];
+    }
+
+    @Override
     public ItemStack makeStack(int color, boolean inverted) {
         return MultipartLightType.CAGE.makeStack(color, inverted);
     }

--- a/illumination/src/main/java/mrtjp/projectred/illumination/part/FalloutLightProperties.java
+++ b/illumination/src/main/java/mrtjp/projectred/illumination/part/FalloutLightProperties.java
@@ -32,6 +32,11 @@ public class FalloutLightProperties extends MultipartLightProperties {
     }
 
     @Override
+    public Cuboid6 getBounds(int side) {
+        return BOUNDS[side];
+    }
+
+    @Override
     public ItemStack makeStack(int color, boolean inverted) {
         return MultipartLightType.FALLOUT.makeStack(color, inverted);
     }

--- a/illumination/src/main/java/mrtjp/projectred/illumination/part/FalloutLightProperties.java
+++ b/illumination/src/main/java/mrtjp/projectred/illumination/part/FalloutLightProperties.java
@@ -4,6 +4,7 @@ import codechicken.lib.render.CCModel;
 import codechicken.lib.vec.Cuboid6;
 import mrtjp.projectred.illumination.MultipartLightProperties;
 import mrtjp.projectred.illumination.MultipartLightType;
+import net.minecraft.client.renderer.texture.TextureAtlas;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
@@ -44,6 +45,7 @@ public class FalloutLightProperties extends MultipartLightProperties {
     @Override
     @OnlyIn(Dist.CLIENT)
     public void onTextureStitchEvent(TextureStitchEvent.Post event) {
+        if (!event.getAtlas().location().equals(TextureAtlas.LOCATION_BLOCKS)) return;
         icon = event.getAtlas().getSprite(new ResourceLocation(MOD_ID, "block/fallout"));
     }
 

--- a/illumination/src/main/java/mrtjp/projectred/illumination/part/FixtureLightProperties.java
+++ b/illumination/src/main/java/mrtjp/projectred/illumination/part/FixtureLightProperties.java
@@ -62,6 +62,11 @@ public class FixtureLightProperties extends MultipartLightProperties {
     }
 
     @Override
+    public Cuboid6 getBounds(int side) {
+        return BOUNDS[side];
+    }
+
+    @Override
     public CCModel getBulbModel(int side) {
         return FixtureLightModels.BULB_MODELS[side];
     }

--- a/illumination/src/main/java/mrtjp/projectred/illumination/part/LanternLightProperties.java
+++ b/illumination/src/main/java/mrtjp/projectred/illumination/part/LanternLightProperties.java
@@ -36,6 +36,11 @@ public class LanternLightProperties extends MultipartLightProperties {
     }
 
     @Override
+    public Cuboid6 getBounds(int side) {
+        return BOUNDS;
+    }
+
+    @Override
     public ItemStack makeStack(int color, boolean inverted) {
         return MultipartLightType.LANTERN.makeStack(color, inverted);
     }

--- a/illumination/src/main/java/mrtjp/projectred/illumination/part/MultipartLightPart.java
+++ b/illumination/src/main/java/mrtjp/projectred/illumination/part/MultipartLightPart.java
@@ -2,20 +2,19 @@ package mrtjp.projectred.illumination.part;
 
 import codechicken.lib.data.MCDataInput;
 import codechicken.lib.data.MCDataOutput;
+import codechicken.lib.vec.Cuboid6;
 import codechicken.lib.vec.Vector3;
 import codechicken.microblock.part.hollow.HollowMicroblockPart;
 import codechicken.multipart.api.MultipartType;
 import codechicken.multipart.api.RedstoneInteractions;
-import codechicken.multipart.api.part.BaseMultipart;
-import codechicken.multipart.api.part.MultiPart;
-import codechicken.multipart.api.part.NormalOcclusionPart;
-import codechicken.multipart.api.part.SlottedPart;
+import codechicken.multipart.api.part.*;
 import codechicken.multipart.api.part.redstone.RedstonePart;
 import codechicken.multipart.block.BlockMultipart;
 import codechicken.multipart.block.TileMultipart;
 import codechicken.multipart.util.PartRayTraceResult;
 import mrtjp.projectred.core.PlacementLib;
 import mrtjp.projectred.illumination.MultipartLightProperties;
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
@@ -30,7 +29,7 @@ import net.minecraft.world.phys.shapes.VoxelShape;
 import javax.annotation.Nullable;
 import java.util.Collections;
 
-public class MultipartLightPart extends BaseMultipart implements SlottedPart, NormalOcclusionPart, RedstonePart {
+public class MultipartLightPart extends BaseMultipart implements SlottedPart, NormalOcclusionPart, RedstonePart, IconHitEffectsPart {
 
     private final MultipartType<?> type;
     private final MultipartLightProperties properties;
@@ -121,6 +120,21 @@ public class MultipartLightPart extends BaseMultipart implements SlottedPart, No
     @Override
     public int getLightEmission() {
         return (isInverted() != powered) ? 15 : 0;
+    }
+
+    @Override
+    public Cuboid6 getBounds() {
+        return properties.getBounds(side);
+    }
+
+    @Override
+    public TextureAtlasSprite getBreakingIcon(PartRayTraceResult hit) {
+        return getBrokenIcon(side);
+    }
+
+    @Override
+    public TextureAtlasSprite getBrokenIcon(int side) {
+        return properties.getIcon(color);
     }
 
     private ItemStack getItem() {


### PR DESCRIPTION
* Fix auto-crafter block not accepting items from tubes and hoppers. Caused by missing ItemHandler capability (fixes #1872)
* Fix broken textures on Fallout lights (fixes #1873)
* Fix missing breaking particles on all multipart lights
* Fix lamp halo rendering issue by working around a Forge bug. This bug was already fixed but has not been back ported to 1.20.1 (fixes #1868)