### PR TITLE
Optimize MovingBlockSuppressorRenderer for common case of no structures

### DIFF
--- a/expansion/src/main/java/mrtjp/projectred/expansion/MovementManager.java
+++ b/expansion/src/main/java/mrtjp/projectred/expansion/MovementManager.java
@@ -45,8 +45,8 @@ import static mrtjp.projectred.expansion.ProjectRedExpansion.LOGGER;
 
 public class MovementManager {
 
-    private static final HashMap<ResourceKey<Level>, MovementManager> SERVER_INSTANCE = new HashMap<>();
-    private static final HashMap<ResourceKey<Level>, MovementManager> CLIENT_INSTANCE = new HashMap<>();
+    private static final IdentityHashMap<ResourceKey<Level>, MovementManager> SERVER_INSTANCE = new IdentityHashMap<>();
+    private static final IdentityHashMap<ResourceKey<Level>, MovementManager> CLIENT_INSTANCE = new IdentityHashMap<>();
 
     private static final int KEY_BULK_DESC = 0x0;
     private static final int KEY_NEW_STRUCT = 0x1;
@@ -63,6 +63,14 @@ public class MovementManager {
     public static MovementManager getInstance(Level level) {
         var map = level.isClientSide() ? CLIENT_INSTANCE : SERVER_INSTANCE;
         return map.computeIfAbsent(level.dimension(), MovementManager::new);
+    }
+
+    public static MovementManager getClientInstanceNullable() {
+        var clientLevel = Minecraft.getInstance().level;
+        if (clientLevel == null) {
+           return null;
+        }
+        return CLIENT_INSTANCE.get(clientLevel.dimension());
     }
 
     public MovementManager(ResourceKey<Level> dimension) {
@@ -293,6 +301,10 @@ public class MovementManager {
         structure.beginMove(level);
 
         return structure;
+    }
+
+    public boolean hasNoMovingStructures() {
+        return structures.isEmpty();
     }
 
     public InternalMovementInfo getMovementInfo(BlockPos pos) {


### PR DESCRIPTION
This PR fixes an issue I actually originally noted & patched in 1.12.2, and then encountered on 1.20.1 when trying out the new ProjectRed beta. The logic to suppress moving blocks runs through quite a bit of logic on every single block in the world, which has a measurable hit to chunk meshing performance (see below profiler screenshot).

![2024-07-30_22-15](https://github.com/user-attachments/assets/da4c0a03-b303-4b17-baf9-e368c2a37315)

To solve this I made a number of optimizations, tailored for the common case of there being no structures in the world:

* Added a direct getter for the client level's `MovementManager` that skips needing to check if the level is client-side, and also skips creating the movement manager if it doesn't exist.
* Make the maps from dimension to `MovementManager` use identity equality & hashing, for slightly better lookup performance.
* Bail out early from `MovingBlockSuppressorRenderer#canHandleBlock` if the movement manager is not tracking any moving structures.
* Hoist retrieval of the `MovementManager` to a local variable in `canHandleBlock`, so it doesn't need to be re-retrieved for the block position & all adjacent positions.

This code could be optimized further to benefit the case where there are structures as well, but the current optimizations are relatively simple & should not break anything, while fully addressing the original issue (see profiling after these changes below).

![2024-07-30_22-21](https://github.com/user-attachments/assets/06b0ecb6-3fbc-49b4-a461-8f5c29ef98de)

