### PR TITLE
Minor fixes and 1.21.1 Release Prep

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -216,6 +216,7 @@ jobs:
         with:
           body_path: CHANGELOG.md
           tag_name: ${{ steps.versioning.outputs.version_tag }}
+          target_commitish: ${{ github.sha }}
           files: |
             */build/libs/ProjectRed-*.jar
             CHANGELOG.md

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -34,9 +34,9 @@ dependencies {
     runtimeOnly("mezz.jei:jei-${mc_version}-neoforge:${jei_version}")
 
     // CCTweaked
-    // compileOnly("cc.tweaked:cc-tweaked-${mc_version}-core-api:${cct_version}")
-    // compileOnly(fg.deobf("cc.tweaked:cc-tweaked-${mc_version}-forge-api:${cct_version}"))
-    // runtimeOnly(fg.deobf("cc.tweaked:cc-tweaked-${mc_version}-forge:${cct_version}"))
+    compileOnly("cc.tweaked:cc-tweaked-${mc_version}-core-api:${cct_version}")
+    compileOnly("cc.tweaked:cc-tweaked-${mc_version}-forge-api:${cct_version}")
+    runtimeOnly("cc.tweaked:cc-tweaked-${mc_version}-forge:${cct_version}")
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'

--- a/core/src/main/java/mrtjp/projectred/compatibility/ComputerCraftCompatibility.java
+++ b/core/src/main/java/mrtjp/projectred/compatibility/ComputerCraftCompatibility.java
@@ -1,46 +1,59 @@
 package mrtjp.projectred.compatibility;
 
-//import dan200.computercraft.api.ComputerCraftAPI;
-//import dan200.computercraft.api.redstone.BundledRedstoneProvider;
+import dan200.computercraft.api.ComputerCraftAPI;
+import dan200.computercraft.api.redstone.BundledRedstoneProvider;
+import mrtjp.projectred.api.IBundledTileInteraction;
+import mrtjp.projectred.api.ProjectRedAPI;
+import mrtjp.projectred.core.BundledSignalsLib;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.Level;
+
+import javax.annotation.Nonnull;
+
+import static mrtjp.projectred.core.ProjectRedCore.LOGGER;
 
 public class ComputerCraftCompatibility {
 
     public static void init(Object ccModObject) {
 
-//        if (ProjectRedAPI.transmissionAPI != null) {
-//            ProjectRedCore.LOGGER.info("Loading Project Red ComputerCraft Compatibility Module");
-//            ComputerCraftAPI.registerBundledRedstoneProvider(new CCPRBundledRedstoneProvider());
-//            ProjectRedAPI.transmissionAPI.registerBundledTileInteraction(new PRCCBundledTileInteraction());
-//        }
+        if (ProjectRedAPI.transmissionAPI != null) {
+            LOGGER.info("Loading Project Red ComputerCraft Compatibility Module");
+            ComputerCraftAPI.registerBundledRedstoneProvider(new CCPRBundledRedstoneProvider());
+            ProjectRedAPI.transmissionAPI.registerBundledTileInteraction(new PRCCBundledTileInteraction());
+        }
     }
 
-//    /**
-//     * This is used by ComputerCraft to query bundled signals from third-party entities
-//     */
-//    private static class CCPRBundledRedstoneProvider implements BundledRedstoneProvider {
-//        @Override
-//        public int getBundledRedstoneOutput(@Nonnull Level world, @Nonnull BlockPos pos, @Nonnull Direction side) {
-//            assert ProjectRedAPI.transmissionAPI != null;
-//            byte[] signal = ProjectRedAPI.transmissionAPI.getBundledInput(world, pos.relative(side), side.getOpposite());
-//            return BundledSignalsLib.packDigital(signal);
-//        }
-//    }
-//
-//    private static class PRCCBundledTileInteraction implements IBundledTileInteraction {
-//        @Override
-//        public boolean isValidInteractionFor(Level world, BlockPos pos, Direction side) {
-//            return ComputerCraftAPI.getBundledRedstoneOutput(world, pos, side) != -1;
-//        }
-//
-//        @Override
-//        public boolean canConnectBundled(Level world, BlockPos pos, Direction side) {
-//            return true;
-//        }
-//
-//        @Override
-//        public byte[] getBundledSignal(Level world, BlockPos pos, Direction side) {
-//            int signal = ComputerCraftAPI.getBundledRedstoneOutput(world, pos, side);
-//            return BundledSignalsLib.unpackDigital(null, signal);
-//        }
-//    }
+    /**
+     * This is used by ComputerCraft to query bundled signals from third-party entities
+     */
+    private static class CCPRBundledRedstoneProvider implements BundledRedstoneProvider {
+        @Override
+        public int getBundledRedstoneOutput(@Nonnull Level world, @Nonnull BlockPos pos, @Nonnull Direction side) {
+            assert ProjectRedAPI.transmissionAPI != null;
+            byte[] signal = ProjectRedAPI.transmissionAPI.getBundledInput(world, pos.relative(side), side.getOpposite());
+            return BundledSignalsLib.packDigital(signal);
+        }
+    }
+
+    /**
+     * Used by Project Red to provide bundled connectivity to third-party blocks
+     */
+    private static class PRCCBundledTileInteraction implements IBundledTileInteraction {
+        @Override
+        public boolean isValidInteractionFor(Level world, BlockPos pos, Direction side) {
+            return ComputerCraftAPI.getBundledRedstoneOutput(world, pos, side) != -1;
+        }
+
+        @Override
+        public boolean canConnectBundled(Level world, BlockPos pos, Direction side) {
+            return true;
+        }
+
+        @Override
+        public byte[] getBundledSignal(Level world, BlockPos pos, Direction side) {
+            int signal = ComputerCraftAPI.getBundledRedstoneOutput(world, pos, side);
+            return BundledSignalsLib.unpackDigital(null, signal);
+        }
+    }
 }

--- a/core/src/main/java/mrtjp/projectred/core/block/ProjectRedBlock.java
+++ b/core/src/main/java/mrtjp/projectred/core/block/ProjectRedBlock.java
@@ -78,7 +78,7 @@ public abstract class ProjectRedBlock extends Block implements EntityBlock {
     public InteractionResult use(BlockState state, Level world, BlockPos pos, Player player, InteractionHand hand, BlockHitResult hit) {
         BlockEntity tile = world.getBlockEntity(pos);
         if (tile instanceof IBlockEventBlockEntity) return ((IBlockEventBlockEntity) tile).onBlockActivated(player, hand, hit);
-        return InteractionResult.FAIL; //TODO pass?
+        return InteractionResult.FAIL;
     }
 
     @Override

--- a/core/src/main/java/mrtjp/projectred/core/client/HaloRenderer.java
+++ b/core/src/main/java/mrtjp/projectred/core/client/HaloRenderer.java
@@ -86,9 +86,6 @@ public class HaloRenderer {
     private static final LinkedList<HaloRenderData> entityHalos = new LinkedList<>();
     // Global offset for moving block entities
     private static final Vector3 offset = Vector3.ZERO.copy();
-    // Used for Forge bug workaround. See onRenderLevelStageEvent
-    // TODO remove when porting to > 1.20.1
-    private static @Nullable PoseStack capturedPoseStack = null;
 
     //region Init and event handlers
     public static void init() {
@@ -111,20 +108,7 @@ public class HaloRenderer {
     public static void onRenderLevelStageEvent(final RenderLevelStageEvent event) {
         if (event.getStage().equals(AFTER_PARTICLES)) {
             onRenderStageAfterParticles(event);
-            capturedPoseStack = event.getPoseStack();
         } else if (event.getStage().equals(AFTER_LEVEL)) {
-            // Workaround for non-backported Forge bug where the AFTER_LEVEL call gets the wrong PoseStack. We will retain the valid
-            // PoseStack from the AFTER_PARTICLE call and reuse it here.
-            // https://github.com/neoforged/NeoForge/pull/231
-            // https://github.com/MrTJP/ProjectRed/issues/1868
-            // TODO remove when porting to > 1.20.1
-            if (capturedPoseStack != null) {
-                var e2 = new RenderLevelStageEvent(event.getStage(), event.getLevelRenderer(), capturedPoseStack, event.getProjectionMatrix(), event.getRenderTick(), event.getPartialTick(), event.getCamera(), event.getFrustum());
-                capturedPoseStack = null;
-                onRenderStageAfterLevel(e2);
-                return;
-            }
-
             onRenderStageAfterLevel(event);
         }
     }

--- a/core/src/main/java/mrtjp/projectred/core/tile/ElectrotineGeneratorBlockEntity.java
+++ b/core/src/main/java/mrtjp/projectred/core/tile/ElectrotineGeneratorBlockEntity.java
@@ -76,7 +76,7 @@ public class ElectrotineGeneratorBlockEntity extends BasePoweredBlockEntity impl
                     p -> p.writePos(getBlockPos()));
         }
 
-        return InteractionResult.SUCCESS;
+        return InteractionResult.sidedSuccess(getLevel().isClientSide);
     }
 
     @Override

--- a/expansion/src/main/java/mrtjp/projectred/expansion/inventory/container/AutoCrafterMenu.java
+++ b/expansion/src/main/java/mrtjp/projectred/expansion/inventory/container/AutoCrafterMenu.java
@@ -46,12 +46,6 @@ public class AutoCrafterMenu extends BaseMachineMenu {
         InventoryLib.addInventory(tile.getPlanInventory(), 0, 44, 22, 3, 3, PlanSlot::new, this::addSlot);
     }
 
-    //TODO copied from superclass due to compile bug. Retest in 1.20.4
-    @Override
-    public boolean stillValid(Player pPlayer) {
-        return Container.stillValidBlockEntity(tile, pPlayer);
-    }
-
     public AutoCrafterBlockEntity getAutoCrafterTile() {
         return tile;
     }

--- a/expansion/src/main/java/mrtjp/projectred/expansion/inventory/container/BatteryBoxMenu.java
+++ b/expansion/src/main/java/mrtjp/projectred/expansion/inventory/container/BatteryBoxMenu.java
@@ -45,12 +45,6 @@ public class BatteryBoxMenu extends BasePoweredBlockEntityMenu {
         addSlot(new BatterySlot(tile.getInventory(), 1, 80, 53)); // discharge slot
     }
 
-    //TODO copied from superclass due to compile bug. Retest in 1.20.4
-    @Override
-    public boolean stillValid(Player pPlayer) {
-        return Container.stillValidBlockEntity(tile, pPlayer);
-    }
-
     @Override
     public ItemStack quickMoveStack(Player player, int slotIndex) {
 

--- a/expansion/src/main/java/mrtjp/projectred/expansion/inventory/container/ChargingBenchMenu.java
+++ b/expansion/src/main/java/mrtjp/projectred/expansion/inventory/container/ChargingBenchMenu.java
@@ -44,12 +44,6 @@ public class ChargingBenchMenu extends BasePoweredBlockEntityMenu {
         InventoryLib.addInventory(tile.getInventory(), 8, 88, 57, 4, 2, ChargeableItemSlot::new, this::addSlot);
     }
 
-    //TODO copied from superclass due to compile bug. Retest in 1.20.4
-    @Override
-    public boolean stillValid(Player pPlayer) {
-        return Container.stillValidBlockEntity(tile, pPlayer);
-    }
-
     @Override
     public ItemStack quickMoveStack(Player player, int slotIndex) {
 

--- a/expansion/src/main/java/mrtjp/projectred/expansion/part/RedstoneTubePart.java
+++ b/expansion/src/main/java/mrtjp/projectred/expansion/part/RedstoneTubePart.java
@@ -2,8 +2,6 @@ package mrtjp.projectred.expansion.part;
 
 import codechicken.lib.data.MCDataInput;
 import codechicken.lib.data.MCDataOutput;
-import codechicken.microblock.api.MicroMaterial;
-import codechicken.microblock.item.ItemMicroBlock;
 import codechicken.multipart.api.RedstoneInteractions;
 import codechicken.multipart.api.part.MultiPart;
 import codechicken.multipart.api.part.redstone.MaskedRedstonePart;
@@ -98,7 +96,8 @@ public class RedstoneTubePart extends BaseTubePart implements IRedstonePropagati
     //region Multipart events
     @Override
     public InteractionResult activate(Player player, PartRayTraceResult hit, ItemStack held, InteractionHand hand) {
-        if (super.activate(player, hit, held, hand).shouldSwing()) return InteractionResult.SUCCESS;
+        var result = super.activate(player, hit, held, hand);
+        if (result.consumesAction()) return result;
 
         // Couch + right click with empty hand removes redstone
         if (held.isEmpty() && player.isCrouching() && hasRedstone) {
@@ -110,12 +109,11 @@ public class RedstoneTubePart extends BaseTubePart implements IRedstonePropagati
                 tile().notifyPartChange(null);
                 sendSignalUpdate();
             }
-            return InteractionResult.SUCCESS;
+            return InteractionResult.sidedSuccess(level().isClientSide);
         }
 
         // Right click with red alloy adds redstone wiring to pipe
         if (!held.isEmpty() && held.is(CoreTags.RED_ALLOY_INGOT_TAG) && !hasRedstone) {
-            MicroMaterial newMat = ItemMicroBlock.getMaterialFromStack(held);
             if (!level().isClientSide) {
                 // Swap the material
                 hasRedstone = true;
@@ -131,7 +129,7 @@ public class RedstoneTubePart extends BaseTubePart implements IRedstonePropagati
                     held.shrink(1);
                 }
             }
-            return InteractionResult.SUCCESS;
+            return InteractionResult.sidedSuccess(level().isClientSide);
         }
 
         return InteractionResult.PASS;

--- a/expansion/src/main/java/mrtjp/projectred/expansion/tile/DeployerBlockEntity.java
+++ b/expansion/src/main/java/mrtjp/projectred/expansion/tile/DeployerBlockEntity.java
@@ -178,7 +178,7 @@ public class DeployerBlockEntity extends BaseDeviceBlockEntity {
         UseOnContext ctx = new UseOnContext(player, InteractionHand.MAIN_HAND, hit);
         if (event.getUseItem() != Event.Result.DENY) {
             InteractionResult result = player.getMainHandItem().onItemUseFirst(ctx);
-            if (result.consumesAction()) {
+            if (result != InteractionResult.PASS) {
                 return result;
             }
         }

--- a/exploration/src/main/java/mrtjp/projectred/exploration/data/ExplorationRecipeProvider.java
+++ b/exploration/src/main/java/mrtjp/projectred/exploration/data/ExplorationRecipeProvider.java
@@ -159,7 +159,6 @@ public class ExplorationRecipeProvider extends RecipeProvider {
             backpackRecipe(getBackpackByColor(i));
         }
 
-        //TODO Now we have to hardcode CraftingBookCategory.MISC?
         special(new ResourceLocation(MOD_ID, "backpack_dye"), () -> new BackpackDyeRecipe(CraftingBookCategory.MISC));
     }
 

--- a/fabrication/src/main/java/mrtjp/projectred/fabrication/gui/screen/inventory/LithographyTableScreen.java
+++ b/fabrication/src/main/java/mrtjp/projectred/fabrication/gui/screen/inventory/LithographyTableScreen.java
@@ -15,7 +15,7 @@ public class LithographyTableScreen extends RedUIContainerScreen<LithographyTabl
     public static final ResourceLocation BACKGROUND = new ResourceLocation(ProjectRedFabrication.MOD_ID, "textures/gui/lithography_table.png");
 
     public LithographyTableScreen(LithographyTableMenu container, Inventory playerInventory, Component title) {
-        super(176, 171, container, playerInventory, title); //TODO size
+        super(176, 171, container, playerInventory, title);
 
         inventoryLabelX = 8;
         inventoryLabelY = 79;

--- a/fabrication/src/main/java/mrtjp/projectred/fabrication/gui/screen/inventory/PackagingTableScreen.java
+++ b/fabrication/src/main/java/mrtjp/projectred/fabrication/gui/screen/inventory/PackagingTableScreen.java
@@ -17,7 +17,7 @@ public class PackagingTableScreen extends RedUIContainerScreen<PackagingTableMen
     public static final ResourceLocation BACKGROUND = new ResourceLocation(ProjectRedFabrication.MOD_ID, "textures/gui/packaging_table.png");
 
     public PackagingTableScreen(PackagingTableMenu container, Inventory playerInventory, Component title) {
-        super(176, 171, container, playerInventory, title); //TODO size
+        super(176, 171, container, playerInventory, title);
 
         inventoryLabelX = 8;
         inventoryLabelY = 79;

--- a/fabrication/src/main/java/mrtjp/projectred/fabrication/gui/screen/inventory/PlottingTableScreen.java
+++ b/fabrication/src/main/java/mrtjp/projectred/fabrication/gui/screen/inventory/PlottingTableScreen.java
@@ -15,7 +15,7 @@ public class PlottingTableScreen extends RedUIContainerScreen<PlottingTableMenu>
     public static final ResourceLocation BACKGROUND = new ResourceLocation(ProjectRedFabrication.MOD_ID, "textures/gui/plotting_table.png");
 
     public PlottingTableScreen(PlottingTableMenu container, Inventory playerInventory, Component title) {
-        super(176, 171, container, playerInventory, title); //TODO size
+        super(176, 171, container, playerInventory, title);
 
         inventoryLabelX = 8;
         inventoryLabelY = 79;

--- a/fabrication/src/main/java/mrtjp/projectred/fabrication/inventory/container/LithographyTableMenu.java
+++ b/fabrication/src/main/java/mrtjp/projectred/fabrication/inventory/container/LithographyTableMenu.java
@@ -42,12 +42,6 @@ public class LithographyTableMenu extends FabricationMachineMenu {
         addSlot(new TakeOnlySlot(tile.getInventory(), 3, 110, 49)); // invalid die output
     }
 
-    //TODO copied from superclass due to compile bug. Retest in 1.20.4
-    @Override
-    public boolean stillValid(Player pPlayer) {
-        return Container.stillValidBlockEntity(tile, pPlayer);
-    }
-
     public ItemStack quickMoveStack(Player player, int slotIndex) {
 
         Slot slot = slots.get(slotIndex);
@@ -124,7 +118,7 @@ public class LithographyTableMenu extends FabricationMachineMenu {
     //@formatter:on
 
     private boolean isPhotomaskSet(ItemStack stack) {
-        return stack.getItem() instanceof PhotomaskSetItem; //TODO check tag
+        return stack.getItem() instanceof PhotomaskSetItem;
     }
 
     private boolean isSiliconWafer(ItemStack stack) {

--- a/fabrication/src/main/java/mrtjp/projectred/fabrication/inventory/container/PackagingTableMenu.java
+++ b/fabrication/src/main/java/mrtjp/projectred/fabrication/inventory/container/PackagingTableMenu.java
@@ -47,12 +47,6 @@ public class PackagingTableMenu extends FabricationMachineMenu {
         addSlot(new TakeOnlySlot(tile.getInventory(), 9, 135, 40));
     }
 
-    //TODO copied from superclass due to compile bug. Retest in 1.20.4
-    @Override
-    public boolean stillValid(Player pPlayer) {
-        return Container.stillValidBlockEntity(tile, pPlayer);
-    }
-
     @Override
     public ItemStack quickMoveStack(Player player, int slotIndex) {
 
@@ -127,6 +121,6 @@ public class PackagingTableMenu extends FabricationMachineMenu {
     //@formatter:on
 
     private boolean isValidDie(ItemStack stack) {
-        return stack.getItem() instanceof ValidDieItem; //TODO check tag
+        return stack.getItem() instanceof ValidDieItem;
     }
 }

--- a/fabrication/src/main/java/mrtjp/projectred/fabrication/inventory/container/PlottingTableMenu.java
+++ b/fabrication/src/main/java/mrtjp/projectred/fabrication/inventory/container/PlottingTableMenu.java
@@ -41,12 +41,6 @@ public class PlottingTableMenu extends FabricationMachineMenu {
         addSlot(new TakeOnlySlot(tile.getInventory(), 2, 116, 40)); // output
     }
 
-    //TODO copied from superclass due to compile bug. Retest in 1.20.4
-    @Override
-    public boolean stillValid(Player pPlayer) {
-        return Container.stillValidBlockEntity(tile, pPlayer);
-    }
-
     @Override
     public ItemStack quickMoveStack(Player player, int slotIndex) {
 
@@ -123,7 +117,7 @@ public class PlottingTableMenu extends FabricationMachineMenu {
     //@formatter:on
 
     private boolean isBlueprint(ItemStack stack) {
-        return stack.getItem() instanceof ICBlueprintItem; //TODO check tag
+        return stack.getItem() instanceof ICBlueprintItem;
     }
 
     private boolean isBlankPhotomask(ItemStack stack) {

--- a/fabrication/src/main/java/mrtjp/projectred/fabrication/tile/ICWorkbenchBlockEntity.java
+++ b/fabrication/src/main/java/mrtjp/projectred/fabrication/tile/ICWorkbenchBlockEntity.java
@@ -120,7 +120,7 @@ public class ICWorkbenchBlockEntity extends ProjectRedBlockEntity implements IPa
             }
         }
 
-        return InteractionResult.SUCCESS;
+        return InteractionResult.sidedSuccess(getLevel().isClientSide);
     }
 
     @Override

--- a/fabrication/src/main/java/mrtjp/projectred/fabrication/tile/LithographyTableBlockEntity.java
+++ b/fabrication/src/main/java/mrtjp/projectred/fabrication/tile/LithographyTableBlockEntity.java
@@ -76,7 +76,7 @@ public class LithographyTableBlockEntity extends FabricationMachineBlockEntity {
                     p -> p.writePos(getBlockPos()));
         }
 
-        return InteractionResult.SUCCESS;
+        return InteractionResult.sidedSuccess(getLevel().isClientSide);
     }
 
     @Override

--- a/fabrication/src/main/java/mrtjp/projectred/fabrication/tile/PackagingTableBlockEntity.java
+++ b/fabrication/src/main/java/mrtjp/projectred/fabrication/tile/PackagingTableBlockEntity.java
@@ -84,7 +84,7 @@ public class PackagingTableBlockEntity extends FabricationMachineBlockEntity imp
                     p -> p.writePos(getBlockPos()));
         }
 
-        return InteractionResult.SUCCESS;
+        return InteractionResult.sidedSuccess(getLevel().isClientSide);
     }
 
     @Override

--- a/fabrication/src/main/java/mrtjp/projectred/fabrication/tile/PlottingTableBlockEntity.java
+++ b/fabrication/src/main/java/mrtjp/projectred/fabrication/tile/PlottingTableBlockEntity.java
@@ -73,7 +73,7 @@ public class PlottingTableBlockEntity extends FabricationMachineBlockEntity {
                     p -> p.writePos(getBlockPos()));
         }
 
-        return InteractionResult.SUCCESS;
+        return InteractionResult.sidedSuccess(getLevel().isClientSide);
     }
 
     @Override

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ ccl_version=4.5.0.+
 cbm_version=3.4.0.+
 
 jei_version=17.3.0.56
-cct_version=1.110.3
+cct_version=1.110.2
 
 fabrication_version=0.1.0-alpha-19
 

--- a/integration/src/main/java/mrtjp/projectred/integration/client/GateModelRenderer.java
+++ b/integration/src/main/java/mrtjp/projectred/integration/client/GateModelRenderer.java
@@ -1920,11 +1920,11 @@ public class GateModelRenderer {
 
             CompoundTag ifspecTag = tag.getCompound("io_spec");
             byte rMask = ifspecTag.getByte("rmask");
-            byte aMask = 0; //TODO analog stuff
+            byte aMask = ifspecTag.getByte("amask");
             byte bMask = ifspecTag.getByte("bmask");
 
             simpleWires.sidemask = rMask & 0xF | (rMask >> 4) & 0xF;
-            analogWires.sidemask = aMask;
+            analogWires.sidemask = aMask & 0xF | (aMask >> 4) & 0xF;
             bundledWires.sidemask = bMask & 0xF | (bMask >> 4) & 0xF;
         }
 

--- a/integration/src/main/java/mrtjp/projectred/integration/part/GatePart.java
+++ b/integration/src/main/java/mrtjp/projectred/integration/part/GatePart.java
@@ -422,7 +422,8 @@ public abstract class GatePart extends BaseMultipart implements IConnectableFace
     //region Activation handling
     @Override
     public InteractionResult activate(Player player, PartRayTraceResult hit, ItemStack held, InteractionHand hand) {
-        if (gateLogicActivate(player, held, hit)) return InteractionResult.SUCCESS;
+        if (gateLogicActivate(player, held, hit))
+            return InteractionResult.sidedSuccess(level().isClientSide);
 
         if (!held.isEmpty() && held.getItem() instanceof IScrewdriver screwdriver) {
             if (!level().isClientSide) {
@@ -433,7 +434,7 @@ public abstract class GatePart extends BaseMultipart implements IConnectableFace
                 }
                 screwdriver.damageScrewdriver(player, held);
             }
-            return InteractionResult.SUCCESS;
+            return InteractionResult.sidedSuccess(level().isClientSide);
         }
 
         return InteractionResult.PASS;

--- a/transmission/src/main/java/mrtjp/projectred/transmission/part/BaseCenterWirePart.java
+++ b/transmission/src/main/java/mrtjp/projectred/transmission/part/BaseCenterWirePart.java
@@ -264,19 +264,19 @@ public abstract class BaseCenterWirePart extends BaseWirePart implements IConnec
 
     @Override
     public InteractionResult activate(Player player, PartRayTraceResult hit, ItemStack held, InteractionHand hand) {
-
-        if (super.activate(player, hit, held, hand).shouldSwing()) return InteractionResult.SUCCESS;
+        var result = super.activate(player, hit, held, hand);
+        if (result.consumesAction()) return result;
 
         // Couch + right click with empty hand removes material
         if (held.isEmpty() && player.isCrouching() && material != null) {
             if (!level().isClientSide) {
-                if (material != null && !player.isCreative()) {
+                if (!player.isCreative()) {
                     PlacementLib.dropTowardsPlayer(level(), pos(), ItemMicroBlock.create(0, 1, material), player);
                 }
                 material = null;
                 sendMaterialUpdate();
             }
-            return InteractionResult.SUCCESS;
+            return InteractionResult.sidedSuccess(level().isClientSide);
         }
 
         // Right click with cover Microblock allows adding a cover material
@@ -309,7 +309,7 @@ public abstract class BaseCenterWirePart extends BaseWirePart implements IConnec
                         held.shrink(1);
                     }
                 }
-                return InteractionResult.SUCCESS;
+                return InteractionResult.sidedSuccess(level().isClientSide);
             }
         }
 


### PR DESCRIPTION
* Remove workaround for non-back ported Forge bug (Fix was pulled into Neoforge 1.21.x via https://github.com/neoforged/NeoForge/pull/231)
* Correct various block and part interaction logic which was returning `SUCCESS` server-side rather than `CONSUME`. There was likely no noticeable effects of this incorrect logic, but it is fixed now nonetheless.
* Fix Fabricated Gate items not rendering Analog connection sides in inventory rendering
* Re-introduce ComputerCraft bundled cable compatibility. This was initially left out as CCTweaked was not ready when PR was ported to 1.20.4.
* Removed compile bug workarounds that are no longer necessary