### PR TITLE
Bug fix for API loading issue

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -8,3 +8,10 @@ neoForge {
 
 dependencies {
 }
+
+jar {
+    manifest {
+        // Required since API uses Minecraft classes
+        attributes 'FMLModType': 'GAMELIBRARY'
+    }
+}

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     accessTransformers "io.codechicken:CBMultipart:${mc_version}-${cbm_version}"
 
     // ProjectRed API
-    jarJar(implementation project(":api")) // Use JarJar to bake within Core jar
+    jarJar(api project(":api")) // Use JarJar to bake within Core jar
 
     // JEI
     compileOnly("mezz.jei:jei-${mc_version}-common-api:${jei_version}")

--- a/expansion/build.gradle
+++ b/expansion/build.gradle
@@ -24,6 +24,5 @@ dependencies {
     accessTransformers "io.codechicken:CodeChickenLib:${mc_version}-${ccl_version}"
     accessTransformers "io.codechicken:CBMultipart:${mc_version}-${cbm_version}"
 
-    implementation project(":api")
     implementation project(":core")
 }

--- a/exploration/build.gradle
+++ b/exploration/build.gradle
@@ -24,6 +24,5 @@ dependencies {
     accessTransformers "io.codechicken:CodeChickenLib:${mc_version}-${ccl_version}"
     accessTransformers "io.codechicken:CBMultipart:${mc_version}-${cbm_version}"
 
-    implementation project(":api")
     implementation project(":core")
 }

--- a/fabrication/build.gradle
+++ b/fabrication/build.gradle
@@ -24,7 +24,6 @@ dependencies {
     accessTransformers "io.codechicken:CodeChickenLib:${mc_version}-${ccl_version}"
     accessTransformers "io.codechicken:CBMultipart:${mc_version}-${cbm_version}"
 
-    implementation project(":api")
     implementation project(":core")
     implementation project(":integration")
     implementation project(":transmission")

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,6 +14,6 @@ fabrication_version=0.1.0-alpha-19
 org.gradle.jvmargs=-Xmx4096M
 
 # The Minecraft version the Parchment version is for
-neogradle.subsystems.parchment.minecraftVersion=1.21.1
+neoForge.parchment.minecraftVersion=1.21.1
 # The version of the Parchment mappings
-neogradle.subsystems.parchment.mappingsVersion=2024.11.17
+neoForge.parchment.mappingsVersion=2024.11.17

--- a/illumination/build.gradle
+++ b/illumination/build.gradle
@@ -24,6 +24,5 @@ dependencies {
     accessTransformers "io.codechicken:CodeChickenLib:${mc_version}-${ccl_version}"
     accessTransformers "io.codechicken:CBMultipart:${mc_version}-${cbm_version}"
 
-    implementation project(":api")
     implementation project(":core")
 }

--- a/integration/build.gradle
+++ b/integration/build.gradle
@@ -24,6 +24,5 @@ dependencies {
     accessTransformers "io.codechicken:CodeChickenLib:${mc_version}-${ccl_version}"
     accessTransformers "io.codechicken:CBMultipart:${mc_version}-${cbm_version}"
 
-    implementation project(":api")
     implementation project(":core")
 }

--- a/transmission/build.gradle
+++ b/transmission/build.gradle
@@ -24,6 +24,5 @@ dependencies {
     accessTransformers "io.codechicken:CodeChickenLib:${mc_version}-${ccl_version}"
     accessTransformers "io.codechicken:CBMultipart:${mc_version}-${cbm_version}"
 
-    implementation project(":api")
     implementation project(":core")
 }


### PR DESCRIPTION
- Enable parchment mappings (renamed properties to what ModDevGradle expects)
- Fix API jar-in-jar not getting access to Minecraft sources at runtime by adding a manifest declaring `GAMELIBRARY` type (Fixes #1972)
- `core` module now consumes `api` project as `api` type rather than `implementation`. All other modules no longer declare a dependency on `api`, as it comes along with `core`.
