### PR TITLE
Bug fixes

### DIFF
--- a/core/src/main/java/mrtjp/projectred/lib/ModelVoxelShape.java
+++ b/core/src/main/java/mrtjp/projectred/lib/ModelVoxelShape.java
@@ -225,7 +225,7 @@ public class ModelVoxelShape extends VoxelShape {
         } else if (absz > absx && absz > absy) {
             return normal.z > 0 ? Direction.SOUTH : Direction.NORTH;
         } else if (absx > absy && absx > absz) {
-            return normal.x > 0 ? Direction.WEST : Direction.EAST;
+            return normal.x > 0 ? Direction.EAST : Direction.WEST;
         } else {
             return null;
         }

--- a/expansion/src/main/java/mrtjp/projectred/expansion/MovementManager.java
+++ b/expansion/src/main/java/mrtjp/projectred/expansion/MovementManager.java
@@ -32,7 +32,6 @@ import net.minecraft.world.phys.Vec3;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.api.distmarker.OnlyIn;
 import net.neoforged.neoforge.client.event.RenderLevelStageEvent;
-import net.neoforged.neoforge.client.model.data.ModelData;
 import net.neoforged.neoforge.event.level.ChunkEvent;
 import net.neoforged.neoforge.event.level.ChunkWatchEvent;
 import net.neoforged.neoforge.event.level.LevelEvent;
@@ -172,7 +171,7 @@ public class MovementManager {
                     stack.translate(p.getX(), p.getY(), p.getZ());
 
                     MovingBlockSuppressorRenderer.allowMovingRenderOnRenderThread = true;
-                    Minecraft.getInstance().getBlockRenderer().renderBatched(state, p, level, stack, buffers.getBuffer(renderType), false, random, ModelData.EMPTY, renderType);
+                    Minecraft.getInstance().getBlockRenderer().renderBatched(state, p, level, stack, buffers.getBuffer(renderType), false, random, level.getModelData(p), renderType);
                     MovingBlockSuppressorRenderer.allowMovingRenderOnRenderThread = false;
 
                     stack.popPose(); //p

--- a/expansion/src/main/java/mrtjp/projectred/expansion/item/IChargable.java
+++ b/expansion/src/main/java/mrtjp/projectred/expansion/item/IChargable.java
@@ -1,5 +1,6 @@
 package mrtjp.projectred.expansion.item;
 
+import net.minecraft.core.component.DataComponents;
 import net.minecraft.util.Tuple;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
@@ -14,7 +15,7 @@ public interface IChargable {
 
         if (getChargedVariant() != getEmptyVariant() && stack.getItem() == getEmptyVariant()) {
             ItemStack chargedStack = new ItemStack(getChargedVariant(), 1);
-            chargedStack.applyComponents(stack.getComponents());
+            chargedStack.set(DataComponents.ENCHANTMENTS, stack.get(DataComponents.ENCHANTMENTS));
             chargedStack.setDamageValue(chargedStack.getMaxDamage());
             stack = chargedStack;
         }
@@ -35,9 +36,8 @@ public interface IChargable {
         stack.setDamageValue(stack.getDamageValue() + toDraw);
 
         if (getChargedVariant() != getEmptyVariant() && stack.getDamageValue() >= stack.getMaxDamage()) {
-            //TODO do not copy damage components
             ItemStack emptyStack = new ItemStack(getEmptyVariant(), 1);
-            emptyStack.applyComponents(stack.getComponents());
+            emptyStack.set(DataComponents.ENCHANTMENTS, stack.get(DataComponents.ENCHANTMENTS));
             stack = emptyStack;
         }
 

--- a/expansion/src/main/java/mrtjp/projectred/expansion/part/FramePartConverter.java
+++ b/expansion/src/main/java/mrtjp/projectred/expansion/part/FramePartConverter.java
@@ -5,8 +5,11 @@ import codechicken.multipart.api.part.MultiPart;
 import codechicken.multipart.util.MultipartPlaceContext;
 import mrtjp.projectred.expansion.init.ExpansionBlocks;
 import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.shapes.CollisionContext;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -29,8 +32,19 @@ public class FramePartConverter extends PartConverter {
     @Override
     public ConversionResult<MultiPart> convert(MultipartPlaceContext context) {
         if (context.getItemInHand().getItem() == ExpansionBlocks.FRAME_BLOCK.get().asItem()) {
-            return ConversionResult.success(new FramePart());
+            BlockState state = ExpansionBlocks.FRAME_BLOCK.get().getStateForPlacement(context);
+            if (state != null && canPlace(context, state)) {
+                return ConversionResult.success(new FramePart());
+            }
         }
         return emptyResult();
+    }
+
+    // Lifted from BlockItem
+    private boolean canPlace(BlockPlaceContext context, BlockState state) {
+        Player player = context.getPlayer();
+        CollisionContext collisioncontext = player == null ? CollisionContext.empty() : CollisionContext.of(player);
+        return (state.canSurvive(context.getLevel(), context.getClickedPos()))
+                && context.getLevel().isUnobstructed(state, context.getClickedPos(), collisioncontext);
     }
 }


### PR DESCRIPTION
- Fix multipart blocks not rendering while moving on frames. Also fixes any block that requires model data to render
- Fix empty batteries retaining an empty damage bar and not stacking
- Fix frame blocks allowing conversion placement (that is, placement onto multipart blocks or blocks that trigger conversion) even if player is colliding
- Fix weird frame block placement against east/west faces
