### PR TITLE
Project bench bug fix

### DIFF
--- a/expansion/src/main/java/mrtjp/projectred/expansion/CraftingHelper.java
+++ b/expansion/src/main/java/mrtjp/projectred/expansion/CraftingHelper.java
@@ -144,8 +144,8 @@ public class CraftingHelper {
             if (remaining.isEmpty()) continue;
 
             // If allowed, leave remaining in crafting grid just like Vanilla crafting bench
-            if (leaveRemainingInGrid && craftingGird.getItem(i).isEmpty()) {
-                int ccSlot = craftingInputSlotToContainer(craftingInventory, posCraftingInput, i);
+            int ccSlot = craftingInputSlotToContainer(craftingInventory, posCraftingInput, i);
+            if (leaveRemainingInGrid && craftingGird.getItem(ccSlot).isEmpty()) {
                 craftingGird.setItem(ccSlot, remaining.split(remaining.getCount()));
                 continue;
             }


### PR DESCRIPTION
Fix project bench leaving remaining items back into crafting matrix even if they were pulled from storage, potentially voiding what was already there (Fixes #1970)