### PR TITLE
fix: prevent red alloy/insulated wire from becoming unpowerable after a thrown lookup

### DIFF
--- a/expansion/src/main/java/mrtjp/projectred/expansion/part/RedstoneTubePart.java
+++ b/expansion/src/main/java/mrtjp/projectred/expansion/part/RedstoneTubePart.java
@@ -208,10 +208,12 @@ public class RedstoneTubePart extends BaseTubePart implements IRedstonePropagati
 
         boolean prevCanConnectRW = RedstonePropagator.canConnectRedwires();
         RedstonePropagator.setCanConnectRedwires(false);
-        boolean discovered = (RedstoneInteractions.otherConnectionMask(level(), pos(), s, false) &
-                RedstoneInteractions.connectionMask(this, s)) != 0;
-        RedstonePropagator.setCanConnectRedwires(prevCanConnectRW);
-        return discovered;
+        try {
+            return (RedstoneInteractions.otherConnectionMask(level(), pos(), s, false) &
+                    RedstoneInteractions.connectionMask(this, s)) != 0;
+        } finally {
+            RedstonePropagator.setCanConnectRedwires(prevCanConnectRW);
+        }
     }
 
     @Override
@@ -248,28 +250,30 @@ public class RedstoneTubePart extends BaseTubePart implements IRedstonePropagati
 
         RedstonePropagator.setDustProvidesPower(false);
         RedstonePropagator.setRedwiresProvidePower(false);
+        try {
+            int signal = 0;
+            for (int s = 0; s < 6; s++) {
+                int sig = 0;
+                if (maskConnectsIn(s)) {
+                    CenterLookup lookup = CenterLookup.lookupInsideFace(level(), pos(), s);
+                    sig = resolveSignal(lookup);
 
-        int signal = 0;
-        for (int s = 0; s < 6; s++) {
-            int sig = 0;
-            if (maskConnectsIn(s)) {
-                CenterLookup lookup = CenterLookup.lookupInsideFace(level(), pos(), s);
-                sig = resolveSignal(lookup);
-
-            } else if (maskConnectsOut(s)) {
-                CenterLookup lookup = CenterLookup.lookupStraightCenter(level(), pos(), s);
-                sig = resolveSignal(lookup);
-                if (sig == 0) {
-                    sig = RedstoneCenterLookup.resolveVanillaSignal(lookup, this);
+                } else if (maskConnectsOut(s)) {
+                    CenterLookup lookup = CenterLookup.lookupStraightCenter(level(), pos(), s);
+                    sig = resolveSignal(lookup);
+                    if (sig == 0) {
+                        sig = RedstoneCenterLookup.resolveVanillaSignal(lookup, this);
+                    }
                 }
+
+                signal = Math.max(sig, signal);
             }
 
-            signal = Math.max(sig, signal);
+            return signal;
+        } finally {
+            RedstonePropagator.setDustProvidesPower(true);
+            RedstonePropagator.setRedwiresProvidePower(true);
         }
-
-        RedstonePropagator.setDustProvidesPower(true);
-        RedstonePropagator.setRedwiresProvidePower(true);
-        return signal;
     }
 
     @Override

--- a/integration/src/main/java/mrtjp/projectred/integration/part/ArrayGatePart.java
+++ b/integration/src/main/java/mrtjp/projectred/integration/part/ArrayGatePart.java
@@ -117,38 +117,40 @@ public abstract class ArrayGatePart extends RedstoneGatePart implements IRedwire
 
         RedstonePropagator.setDustProvidesPower(false);
         RedstonePropagator.setRedwiresProvidePower(false);
+        try {
+            int signal = 0;
+            for (int r = 0; r < 4; r++) {
+                if ((propagationMask & 1 << r) == 0) { continue; }
+                int s;
 
-        int signal = 0;
-        for (int r = 0; r < 4; r++) {
-            if ((propagationMask & 1 << r) == 0) { continue; }
-            int s;
+                if (maskConnectsCorner(r)) {
+                    FaceLookup lookup = FaceLookup.lookupCorner(level(), pos(), getSide(), r);
+                    s = RedstoneFaceLookup.resolveSignal(lookup, true);
 
-            if (maskConnectsCorner(r)) {
-                FaceLookup lookup = FaceLookup.lookupCorner(level(), pos(), getSide(), r);
-                s = RedstoneFaceLookup.resolveSignal(lookup, true);
+                } else if (maskConnectsStraight(r)) {
+                    FaceLookup lookup = FaceLookup.lookupStraight(level(), pos(), getSide(), r);
+                    s = RedstoneFaceLookup.resolveSignal(lookup, true);
+                    if (s == 0) {
+                        s = RedstoneFaceLookup.resolveVanillaSignal(lookup, this, true, true);
+                    }
 
-            } else if (maskConnectsStraight(r)) {
-                FaceLookup lookup = FaceLookup.lookupStraight(level(), pos(), getSide(), r);
-                s = RedstoneFaceLookup.resolveSignal(lookup, true);
-                if (s == 0) {
+                } else if (maskConnectsInside(r)) {
+                    FaceLookup lookup = FaceLookup.lookupInsideFace(level(), pos(), getSide(), r);
+                    s = RedstoneFaceLookup.resolveSignal(lookup, true);
+
+                } else { // For non-connected sides, just do a vanilla signal lookup
+                    FaceLookup lookup = FaceLookup.lookupStraight(level(), pos(), getSide(), r);
                     s = RedstoneFaceLookup.resolveVanillaSignal(lookup, this, true, true);
                 }
 
-            } else if (maskConnectsInside(r)) {
-                FaceLookup lookup = FaceLookup.lookupInsideFace(level(), pos(), getSide(), r);
-                s = RedstoneFaceLookup.resolveSignal(lookup, true);
-
-            } else { // For non-connected sides, just do a vanilla signal lookup
-                FaceLookup lookup = FaceLookup.lookupStraight(level(), pos(), getSide(), r);
-                s = RedstoneFaceLookup.resolveVanillaSignal(lookup, this, true, true);
+                signal = Math.max(s, signal);
             }
 
-            signal = Math.max(s, signal);
+            return signal;
+        } finally {
+            RedstonePropagator.setDustProvidesPower(true);
+            RedstonePropagator.setRedwiresProvidePower(true);
         }
-
-        RedstonePropagator.setDustProvidesPower(true);
-        RedstonePropagator.setRedwiresProvidePower(true);
-        return signal;
     }
 
     @Override

--- a/transmission/src/main/java/mrtjp/projectred/transmission/part/FramedRedwirePart.java
+++ b/transmission/src/main/java/mrtjp/projectred/transmission/part/FramedRedwirePart.java
@@ -113,10 +113,12 @@ public abstract class FramedRedwirePart extends BaseCenterWirePart implements IR
     public boolean discoverStraightOverride(int s) {
         boolean prevCanConnectRW = RedstonePropagator.canConnectRedwires();
         RedstonePropagator.setCanConnectRedwires(false);
-        boolean discovered = (RedstoneInteractions.otherConnectionMask(level(), pos(), s, false) &
-                RedstoneInteractions.connectionMask(this, s)) != 0;
-        RedstonePropagator.setCanConnectRedwires(prevCanConnectRW);
-        return discovered;
+        try {
+            return (RedstoneInteractions.otherConnectionMask(level(), pos(), s, false) &
+                    RedstoneInteractions.connectionMask(this, s)) != 0;
+        } finally {
+            RedstonePropagator.setCanConnectRedwires(prevCanConnectRW);
+        }
     }
 
     @Override
@@ -149,28 +151,30 @@ public abstract class FramedRedwirePart extends BaseCenterWirePart implements IR
     public int calculateSignal() {
         RedstonePropagator.setDustProvidesPower(false);
         RedstonePropagator.setRedwiresProvidePower(false);
+        try {
+            int signal = 0;
+            for (int s = 0; s < 6; s++) {
+                int sig = 0;
+                if (maskConnectsIn(s)) {
+                    CenterLookup lookup = CenterLookup.lookupInsideFace(level(), pos(), s);
+                    sig = resolveSignal(lookup);
 
-        int signal = 0;
-        for (int s = 0; s < 6; s++) {
-            int sig = 0;
-            if (maskConnectsIn(s)) {
-                CenterLookup lookup = CenterLookup.lookupInsideFace(level(), pos(), s);
-                sig = resolveSignal(lookup);
-
-            } else if (maskConnectsOut(s)) {
-                CenterLookup lookup = CenterLookup.lookupStraightCenter(level(), pos(), s);
-                sig = resolveSignal(lookup);
-                if (sig == 0) {
-                    sig = RedstoneCenterLookup.resolveVanillaSignal(lookup, this);
+                } else if (maskConnectsOut(s)) {
+                    CenterLookup lookup = CenterLookup.lookupStraightCenter(level(), pos(), s);
+                    sig = resolveSignal(lookup);
+                    if (sig == 0) {
+                        sig = RedstoneCenterLookup.resolveVanillaSignal(lookup, this);
+                    }
                 }
+
+                signal = Math.max(sig, signal);
             }
 
-            signal = Math.max(sig, signal);
+            return signal;
+        } finally {
+            RedstonePropagator.setDustProvidesPower(true);
+            RedstonePropagator.setRedwiresProvidePower(true);
         }
-
-        RedstonePropagator.setDustProvidesPower(true);
-        RedstonePropagator.setRedwiresProvidePower(true);
-        return signal;
     }
 
     @Override

--- a/transmission/src/main/java/mrtjp/projectred/transmission/part/RedwirePart.java
+++ b/transmission/src/main/java/mrtjp/projectred/transmission/part/RedwirePart.java
@@ -123,10 +123,12 @@ public abstract class RedwirePart extends BaseFaceWirePart implements IRedstoneP
     public boolean discoverStraightOverride(int absDir) {
         boolean prevCanConnectRW = RedstonePropagator.canConnectRedwires();
         RedstonePropagator.setCanConnectRedwires(true);
-        boolean discovered = (RedstoneInteractions.otherConnectionMask(level(), pos(), absDir, false) &
-                RedstoneInteractions.connectionMask(this, absDir)) != 0;
-        RedstonePropagator.setCanConnectRedwires(prevCanConnectRW);
-        return discovered;
+        try {
+            return (RedstoneInteractions.otherConnectionMask(level(), pos(), absDir, false) &
+                    RedstoneInteractions.connectionMask(this, absDir)) != 0;
+        } finally {
+            RedstonePropagator.setCanConnectRedwires(prevCanConnectRW);
+        }
     }
 
     @Override
@@ -164,46 +166,47 @@ public abstract class RedwirePart extends BaseFaceWirePart implements IRedstoneP
     public int calculateSignal() {
         RedstonePropagator.setDustProvidesPower(false);
         RedstonePropagator.setRedwiresProvidePower(false);
+        try {
+            int signal = 0;
 
-        int signal = 0;
+            for (int r = 0; r < 4; r++) {
+                int s = 0;
+                if (maskConnectsCorner(r)) {
+                    FaceLookup lookup = FaceLookup.lookupCorner(level(), pos(), getSide(), r);
+                    s = resolveSignal(lookup);
 
-        for (int r = 0; r < 4; r++) {
-            int s = 0;
-            if (maskConnectsCorner(r)) {
-                FaceLookup lookup = FaceLookup.lookupCorner(level(), pos(), getSide(), r);
-                s = resolveSignal(lookup);
+                } else if (maskConnectsStraight(r)) {
+                    FaceLookup lookup = FaceLookup.lookupStraight(level(), pos(), getSide(), r);
+                    s = resolveSignal(lookup);
+                    if (s <= 0) {
+                        s = RedstoneFaceLookup.resolveVanillaSignal(lookup, this, true, true);
+                    }
 
-            } else if (maskConnectsStraight(r)) {
-                FaceLookup lookup = FaceLookup.lookupStraight(level(), pos(), getSide(), r);
-                s = resolveSignal(lookup);
-                if (s <= 0) {
-                    s = RedstoneFaceLookup.resolveVanillaSignal(lookup, this, true, true);
+                } else if (maskConnectsInside(r)) {
+                    FaceLookup lookup = FaceLookup.lookupInsideFace(level(), pos(), getSide(), r);
+                    s = resolveSignal(lookup);
                 }
 
-            } else if (maskConnectsInside(r)) {
-                FaceLookup lookup = FaceLookup.lookupInsideFace(level(), pos(), getSide(), r);
-                s = resolveSignal(lookup);
+                signal = Math.max(s, signal);
             }
 
-            signal = Math.max(s, signal);
+            if (powerUnderside()) {
+                Direction face = Direction.values()[getSide()];
+                int s = level().getSignal(pos().relative(face), face) * 17;
+                signal = Math.max(s, signal);
+            }
+
+            if (maskConnectsCenter()) {
+                FaceLookup lookup = FaceLookup.lookupInsideCenter(level(), pos(), getSide());
+                int s = resolveSignal(lookup);
+                signal = Math.max(s, signal);
+            }
+
+            return signal;
+        } finally {
+            RedstonePropagator.setDustProvidesPower(true);
+            RedstonePropagator.setRedwiresProvidePower(true);
         }
-
-        if (powerUnderside()) {
-            Direction face = Direction.values()[getSide()];
-            int s = level().getSignal(pos().relative(face), face) * 17;
-            signal = Math.max(s, signal);
-        }
-
-        if (maskConnectsCenter()) {
-            FaceLookup lookup = FaceLookup.lookupInsideCenter(level(), pos(), getSide());
-            int s = resolveSignal(lookup);
-            signal = Math.max(s, signal);
-        }
-
-        RedstonePropagator.setDustProvidesPower(true);
-        RedstonePropagator.setRedwiresProvidePower(true);
-
-        return signal;
     }
     //endregion
 


### PR DESCRIPTION
## Summary

`RedstonePropagator`'s global redstone flags are toggled around connection discovery and signal calculation **without `try`/`finally`**, so a neighbor lookup that throws mid-way leaves the static flag stuck in its temporary value for the rest of the session.

Most visibly, `FramedRedwirePart` and `RedstoneTubePart#discoverStraightOverride` set `canConnectRedwires = false` and restore it afterwards. If `RedstoneInteractions.{otherConnectionMask,connectionMask}` throws (e.g. a modded neighbor, or a partially-loaded/unloaded chunk during the lookup), the restore line is skipped and the flag is left `false`.

`RedwirePart#canConnectRedstone` is the only consumer of `canConnectRedwires()`. Once it is stuck `false`, **every face red alloy / insulated wire reports no redstone connection** and reads zero vanilla power through `RedstoneInteractions.getPowerTo` — so newly placed (and existing) wires can no longer be powered at all. Gates and vanilla redstone dust are unaffected (different flags / code paths), which is exactly why only the wires appear broken.

The flags are only reset on `ServerAboutToStartEvent`, so:
- on a **dedicated server** the corruption persists for the entire session (matches the reported "lever-next-to-red-alloy-wire stops working mid-session, even a straight line"), while
- in **singleplayer** it silently recovers on each world reload, which is why it's hard to reproduce there.

## Fix

Wrap every `RedstonePropagator` flag toggle in `try`/`finally` so the flags are always restored, even if a lookup throws:

- `canConnectRedwires` in `discoverStraightOverride` (`RedwirePart`, `FramedRedwirePart`, `RedstoneTubePart`)
- the `dustProvidesPower` / `redwiresProvidePower` flags in `calculateSignal` (`RedwirePart`, `FramedRedwirePart`, `RedstoneTubePart`, `ArrayGatePart`)

No behavioral change on the happy path — only exception safety. The flag handling is identical across `1.20.1`, `1.20.4`, and `1.21.1`, so the same fix is being submitted to each active branch.
