### PR TITLE
Fix stacked crafting ingredient consumption

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,5 +66,5 @@ white-list.txt.converted
 whitelist.json
 world-20140811-075700.zip
 .cache
-
+.vscode/
 gradle.properties

--- a/src/mrtjp/projectred/expansion/TileProjectBench.scala
+++ b/src/mrtjp/projectred/expansion/TileProjectBench.scala
@@ -244,18 +244,40 @@ class CraftingResultTestHelper
 
         for (i <- 0 until 9) {
             val prevInput = invCrafting.getStackInSlot(i)
-            if (!prevInput.isEmpty && !eatIngredient(0, { input =>
-                invCrafting.setInventorySlotContents(i, input)
-                val resultSame = recipe.matches(invCrafting, w) && ItemStack.areItemStacksEqual(recipe.getCraftingResult(invCrafting), result)
-                invCrafting.setInventorySlotContents(i, prevInput)
-                resultSame
-            })) return (ItemStack.EMPTY, null)
+            if (!prevInput.isEmpty && !eatIngredient(0, getIngredientCount(i, _, result, w)))
+                return (ItemStack.EMPTY, null)
         }
 
         (result, recipe.getRemainingItems(invCrafting))
     }
 
-    private def eatIngredient(startIdx:Int, matchFunc:ItemStack => Boolean):Boolean =
+    // Modded recipes may require more than one item in a crafting slot. Find the
+    // smallest candidate stack that still matches so normal recipes consume one.
+    private def getIngredientCount(slot:Int, input:ItemStack, result:ItemStack, w:World):Int =
+    {
+        val prevInput = invCrafting.getStackInSlot(slot)
+        val testInput = input.copy
+        var count = 1
+
+        try {
+            while (count <= input.getCount) {
+                testInput.setCount(count)
+                invCrafting.setInventorySlotContents(slot, testInput)
+
+                if (recipe.matches(invCrafting, w) &&
+                    ItemStack.areItemStacksEqual(recipe.getCraftingResult(invCrafting), result))
+                    return count
+
+                count += 1
+            }
+        } finally {
+            invCrafting.setInventorySlotContents(slot, prevInput)
+        }
+
+        0
+    }
+
+    private def eatIngredient(startIdx:Int, getCount:ItemStack => Int):Boolean =
     {
         var i = startIdx
         def increment() = {
@@ -263,9 +285,10 @@ class CraftingResultTestHelper
         }
         do {
             val stack2 = storage(i)
-            if (!stack2.isEmpty && matchFunc(stack2)) {
-                if (stack2.getCount >= 1) {
-                    stack2.shrink(1)
+            if (!stack2.isEmpty) {
+                val count = getCount(stack2)
+                if (count > 0) {
+                    stack2.shrink(count)
                     return true
                 }
             }


### PR DESCRIPTION
## What changed

- Determine the minimum number of items a candidate stack needs for each crafting slot while preserving the selected recipe and output.
- Consume that recipe-required count instead of always shrinking the source stack by one.
- Ignore local VS Code workspace metadata.

## Why

The 1.12.x project bench crafting helper always removed exactly one item for every occupied crafting slot. Modded recipes can require larger per-slot stack sizes; IC2 Classic's plasma core recipe, for example, requires two magnets or four advanced alloys in its respective slots. ProjectRed would produce the output while under-consuming those ingredients, causing the duplication reported in xJon/Tekkit-2#266.

The new lookup still resolves to one item for vanilla-style recipes, while count-sensitive recipes consume the smallest stack size that continues to match and produces the same output. Candidate item substitutions remain subject to the existing recipe and output checks.

## Validation

- `./gradlew compileScala --no-daemon` with Temurin JDK 8
- `./gradlew build --no-daemon` with Temurin JDK 8
- `git diff --check`

Related: xJon/Tekkit-2#266
